### PR TITLE
24 connect auth pages to backend

### DIFF
--- a/app/src/main/java/se/hkr/andriod/data/network/AuthService.kt
+++ b/app/src/main/java/se/hkr/andriod/data/network/AuthService.kt
@@ -1,0 +1,60 @@
+package se.hkr.andriod.data.network
+
+import okhttp3.*
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+import java.io.IOException
+
+class AuthService {
+    private val client = OkHttpClient()
+
+    fun login(
+        ip: String,
+        username: String,
+        password: String,
+        onResult: (Boolean, String?) -> Unit
+    ) {
+        val url = "http://$ip:8081/login"
+
+        val json = JSONObject()
+        json.put("username", username)
+        json.put("password", password)
+
+        val body = json.toString()
+            .toRequestBody("application/json".toMediaType())
+
+        val request = Request.Builder()
+            .url(url)
+            .post(body)
+            .build()
+
+        client.newCall(request).enqueue(object : Callback {
+
+            override fun onFailure(call: Call, e: IOException) {
+                onResult(false, e.message)
+            }
+
+            override fun onResponse(call: Call, response: Response) {
+                val responseBody = response.body?.string()
+
+                if (!response.isSuccessful || responseBody == null) {
+                    onResult(false, "Login failed")
+                    return
+                }
+
+                try {
+                    val jsonResponse = JSONObject(responseBody)
+                    val token = jsonResponse.getString("accessToken")
+
+                    AuthSession.saveToken(token)
+
+                    onResult(true, token)
+
+                } catch (e: Exception) {
+                    onResult(false, e.message)
+                }
+            }
+        })
+    }
+}

--- a/app/src/main/java/se/hkr/andriod/data/network/AuthSession.kt
+++ b/app/src/main/java/se/hkr/andriod/data/network/AuthSession.kt
@@ -1,0 +1,21 @@
+package se.hkr.andriod.data.network
+
+object AuthSession {
+    private var accessToken: String? = null
+
+    fun saveToken(token: String) {
+        accessToken = token
+    }
+
+    fun getToken(): String? {
+        return accessToken
+    }
+
+    fun clear() {
+        accessToken = null
+    }
+
+    fun isLoggedIn(): Boolean {
+        return accessToken != null
+    }
+}

--- a/app/src/main/java/se/hkr/andriod/data/network/ConnectionManager.kt
+++ b/app/src/main/java/se/hkr/andriod/data/network/ConnectionManager.kt
@@ -8,30 +8,38 @@ class ConnectionManager(private val udpPort: Int = 4444) {
     val deviceStore = DeviceStore(webSocketManager) // central device store
 
     private var isListening = false
+    private var backendIp: String? = null
 
     fun startConnection(onResult: (String?) -> Unit) {
         udpDiscovery.discoverServer(port = udpPort) { ip ->
             if (ip != null) {
                 Log.d("CONNECTION", "Backend discovered at $ip")
+                backendIp = ip
 
-                // Connect WebSocket automatically
-                webSocketManager.connect(ip)
-
-                // Start listening to messages if not already
-                if (!isListening) {
-                    webSocketManager.addMessageListener { message ->
-                        Log.d("CONNECTION", "Received message: $message")
-                        deviceStore.handleIncomingMessage(message)
-                    }
-                    isListening = true
-                }
-
-                // Notify caller
                 onResult(ip)
             } else {
                 Log.d("CONNECTION", "Backend discovery failed")
                 onResult(null)
             }
+        }
+    }
+
+    // Connect WebSocket automatically
+    fun connectWebSocket() {
+        val ip = backendIp ?: run {
+            Log.d("CONNECTION", "No backend IP available")
+            return
+        }
+
+        webSocketManager.connect(ip)
+
+        // Start listening to messages if not already
+        if (!isListening) {
+            webSocketManager.addMessageListener { message ->
+                Log.d("CONNECTION", "Received message: $message")
+                deviceStore.handleIncomingMessage(message)
+            }
+            isListening = true
         }
     }
 

--- a/app/src/main/java/se/hkr/andriod/data/network/WebSocketManager.kt
+++ b/app/src/main/java/se/hkr/andriod/data/network/WebSocketManager.kt
@@ -11,7 +11,15 @@ class WebSocketManager {
     private val messageListeners = mutableListOf<(String) -> Unit>()
 
     fun connect(ip: String, port: Int = 8080) {
-        val url = "ws://$ip:$port"
+
+        val token = AuthSession.getToken()
+
+        val url = if (token != null) {
+            "ws://$ip:$port?token=$token"
+        } else {
+            "ws://$ip:$port"
+        }
+
         Log.d("WEBSOCKET", "Connecting to $url")
 
         val request = Request.Builder().url(url).build()

--- a/app/src/main/java/se/hkr/andriod/ui/screens/login/LoginScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/login/LoginScreen.kt
@@ -100,12 +100,11 @@ fun LoginScreen(
                     Spacer(modifier = Modifier.height(16.dp))
 
                     AppTextField(
-                        label = stringResource(R.string.email_label),
-                        value = uiState.email,
-                        onValueChange = { viewModel.onEmailChanged(it) },
-                        placeholder = stringResource(R.string.email_placeholder),
-                        keyboardType = androidx.compose.ui.text.input.KeyboardType.Email,
-                        errorText = uiState.emailError?.let { stringResource(it) }
+                        label = stringResource(R.string.username_label),
+                        value = uiState.username,
+                        onValueChange = { viewModel.onUsernameChanged(it) },
+                        placeholder = stringResource(R.string.username_placeholder),
+                        errorText = uiState.usernameError?.let { stringResource(it) }
                     )
 
                     AppTextField(

--- a/app/src/main/java/se/hkr/andriod/ui/screens/login/LoginViewModel.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/login/LoginViewModel.kt
@@ -2,61 +2,117 @@ package se.hkr.andriod.ui.screens.login
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import se.hkr.andriod.R
+import se.hkr.andriod.data.network.AuthService
+import se.hkr.andriod.data.network.ConnectionManager
 
 data class LoginUiState(
-    val email: String = "",
+    val username: String = "",
     val password: String = "",
     val isLoading: Boolean = false,
-    val emailError: Int? = null,
+    val usernameError: Int? = null,
     val passwordError: Int? = null,
+    val loginError: String? = null,
     val navigateToHome: Boolean = false
 )
 
-class LoginViewModel : ViewModel() {
+class LoginViewModel(
+    private val connectionManager: ConnectionManager = ConnectionManager(),
+    private val authService: AuthService = AuthService()
+) : ViewModel() {
 
     private val _uiState = MutableStateFlow(LoginUiState())
     val uiState: StateFlow<LoginUiState> = _uiState
 
-    fun onEmailChanged(email: String) {
-        _uiState.update { it.copy(email = email, emailError = null) }
+    fun onUsernameChanged(username: String) {
+        _uiState.update { it.copy(username = username, usernameError = null, loginError = null) }
     }
 
     fun onPasswordChanged(password: String) {
-        _uiState.update { it.copy(password = password, passwordError = null) }
+        _uiState.update { it.copy(password = password, passwordError = null, loginError = null) }
     }
 
     fun onLoginClicked() {
         val currentState = _uiState.value
         var hasError = false
-        var emailErrorId: Int? = null
+        var usernameErrorId: Int? = null
         var passwordErrorId: Int? = null
 
-        if (currentState.email.isBlank()) {
-            emailErrorId = R.string.error_email_empty
+        if (currentState.username.isBlank()) {
+            usernameErrorId = R.string.error_username_empty
             hasError = true
         }
 
-        if (currentState.password.length < 8) {
+        if (currentState.password.length < 4) {
             passwordErrorId = R.string.error_password_short
             hasError = true
         }
 
         if (hasError) {
-            _uiState.update { it.copy(emailError = emailErrorId, passwordError = passwordErrorId) }
+            _uiState.update {
+                it.copy(
+                    usernameError = usernameErrorId,
+                    passwordError = passwordErrorId
+                )
+            }
             return
         }
 
-        // Simulate loading
+        _uiState.update { it.copy(isLoading = true) }
+
         viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = true, emailError = null, passwordError = null) }
-            delay(1500) // simulate network call
-            _uiState.update { it.copy(isLoading = false, navigateToHome = true) }
+
+            try {
+                val username = currentState.username
+                val password = currentState.password
+
+                // Discover backend first
+                connectionManager.startConnection { ip ->
+
+                    if (ip == null) {
+                        _uiState.update {
+                            it.copy(
+                                isLoading = false,
+                                loginError = "Backend not found"
+                            )
+                        }
+                        return@startConnection
+                    }
+
+                    // Login request
+                    authService.login(ip, username, password) { success, result ->
+
+                        if (!success) {
+                            _uiState.update {
+                                it.copy(
+                                    isLoading = false,
+                                    loginError = result ?: "Login failed"
+                                )
+                            }
+                            return@login
+                        }
+
+                        _uiState.update {
+                            it.copy(
+                                isLoading = false,
+                                navigateToHome = true
+                            )
+                        }
+                    }
+                }
+
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        loginError = e.message ?: "Unknown error"
+                    )
+                }
+            }
         }
     }
 

--- a/app/src/main/java/se/hkr/andriod/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/settings/SettingsScreen.kt
@@ -148,7 +148,12 @@ fun SettingsScreen(
                         onClick = {
                             discoveredIp = "Searching..."
                             connectionManager.startConnection { ip ->
-                                discoveredIp = ip ?: "No backend found"
+                                if (ip == null) {
+                                    discoveredIp = "No backend found"
+                                    return@startConnection
+                                }
+                                discoveredIp = ip
+                                connectionManager.connectWebSocket()
                             }
                         },
                         modifier = Modifier.width(160.dp)

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -14,6 +14,9 @@
     <string name="dont_have_account_text">Nincs még fiókod?</string>
     <string name="error_email_empty">Az email nem lehet üres</string>
     <string name="error_password_short">A jelszónak legalább 8 karakter hosszúnak kell lennie</string>
+    <string name="username_label">Felhasználónév</string>
+    <string name="username_placeholder">felhasználónév</string>
+    <string name="error_username_empty">A felhasználónév nem lehet üres</string>
     <string name="signing_in">Bejelentkezés...</string>
 
     <!-- Sign up -->

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -17,6 +17,9 @@
     <string name="dont_have_account_text">Har du inget konto?</string>
     <string name="error_email_empty">E-post får inte vara tom</string>
     <string name="error_password_short">Lösenordet måste vara minst 8 tecken</string>
+    <string name="username_label">Användarnamn</string>
+    <string name="username_placeholder">användarnamn</string>
+    <string name="error_username_empty">Användarnamn får inte vara tomt</string>
     <string name="signing_in">Loggar in...</string>
 
     <!-- Sign up -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,9 @@
     <string name="dont_have_account_text">Don\'t have an account?</string>
     <string name="error_email_empty">Email cannot be empty</string>
     <string name="error_password_short">Password must be at least 8 characters</string>
+    <string name="username_label">Username</string>
+    <string name="username_placeholder">username</string>
+    <string name="error_username_empty">Username cannot be empty</string>
     <string name="signing_in">Signing in...</string>
 
     <!-- Sign up -->


### PR DESCRIPTION
Add AuthSession and AuthService to handle the auth connection and token storage. Updated ConnectionManager and WebSocketManager to work with the new auth logic.
Updated the login screen to work with the new auth logic and to work with usernames instead of emails.
Temporary websocketconnection button in settings is now using the new auth logic. 

NOTE: This branch only focused on the login page and the register page will be split out into a seperate branch.