### PR TITLE
95 implement persistent cookiejar

### DIFF
--- a/app/src/main/java/se/hkr/andriod/data/network/AuthService.kt
+++ b/app/src/main/java/se/hkr/andriod/data/network/AuthService.kt
@@ -1,13 +1,14 @@
 package se.hkr.andriod.data.network
 
+import android.content.Context
 import okhttp3.*
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.json.JSONObject
 import java.io.IOException
 
-class AuthService {
-    private val client = OkHttpClient()
+class AuthService(context: Context) {
+    private val client = NetworkModule.getClient(context)
 
     private fun postRequest(
         url: String,

--- a/app/src/main/java/se/hkr/andriod/data/network/NetworkModule.kt
+++ b/app/src/main/java/se/hkr/andriod/data/network/NetworkModule.kt
@@ -1,0 +1,17 @@
+package se.hkr.andriod.data.network
+
+import android.content.Context
+import okhttp3.OkHttpClient
+
+object NetworkModule {
+    private var client: OkHttpClient? = null
+
+    fun getClient(context: Context): OkHttpClient {
+        if (client == null) {
+            client = OkHttpClient.Builder()
+                .cookieJar(PersistentCookieJar(context))
+                .build()
+        }
+        return client!!
+    }
+}

--- a/app/src/main/java/se/hkr/andriod/data/network/PersistentCookieJar.kt
+++ b/app/src/main/java/se/hkr/andriod/data/network/PersistentCookieJar.kt
@@ -1,0 +1,78 @@
+package se.hkr.andriod.data.network
+
+import android.content.Context
+import okhttp3.Cookie
+import okhttp3.CookieJar
+import okhttp3.HttpUrl
+import org.json.JSONArray
+import androidx.core.content.edit
+
+class PersistentCookieJar(context: Context) : CookieJar {
+    private val prefs = context.getSharedPreferences("cookies", Context.MODE_PRIVATE)
+
+    override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
+        val storedCookies = loadAllCookies().toMutableList()
+
+        cookies.forEach { newCookie ->
+            storedCookies.removeAll {
+                it.name == newCookie.name && it.domain == newCookie.domain
+            }
+            storedCookies.add(newCookie)
+        }
+        saveAllCookies(storedCookies)
+    }
+
+    override fun loadForRequest(url: HttpUrl): List<Cookie> {
+        val cookies = loadAllCookies()
+
+        return cookies.filter { it.matches(url) }
+    }
+
+    fun clear() {
+        prefs.edit { clear() }
+    }
+
+    private fun saveAllCookies(cookies: List<Cookie>) {
+        val jsonArray = JSONArray()
+
+        cookies.forEach { cookie ->
+            val json = org.json.JSONObject().apply {
+                put("name", cookie.name)
+                put("value", cookie.value)
+                put("domain", cookie.domain)
+                put("path", cookie.path)
+                put("expiresAt", cookie.expiresAt)
+                put("secure", cookie.secure)
+                put("httpOnly", cookie.httpOnly)
+            }
+            jsonArray.put(json)
+        }
+        prefs.edit { putString("cookie_list", jsonArray.toString()) }
+    }
+
+    private fun loadAllCookies(): List<Cookie> {
+        val jsonString = prefs.getString("cookie_list", null) ?: return emptyList()
+
+        val jsonArray = JSONArray(jsonString)
+        val cookies = mutableListOf<Cookie>()
+
+        for (i in 0 until jsonArray.length()) {
+            val json = jsonArray.getJSONObject(i)
+
+            val cookie = Cookie.Builder()
+                .name(json.getString("name"))
+                .value(json.getString("value"))
+                .domain(json.getString("domain"))
+                .path(json.getString("path"))
+                .expiresAt(json.getLong("expiresAt"))
+                .apply {
+                    if (json.getBoolean("secure")) secure()
+                    if (json.getBoolean("httpOnly")) httpOnly()
+                }
+                .build()
+
+            cookies.add(cookie)
+        }
+        return cookies
+    }
+}

--- a/app/src/main/java/se/hkr/andriod/navigation/AppNavGraph.kt
+++ b/app/src/main/java/se/hkr/andriod/navigation/AppNavGraph.kt
@@ -1,6 +1,8 @@
 package se.hkr.andriod.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -10,6 +12,7 @@ import se.hkr.andriod.ui.screens.login.LoginViewModel
 import se.hkr.andriod.ui.screens.main.MainScreen
 import se.hkr.andriod.ui.screens.signup.SignUpScreen
 import se.hkr.andriod.ui.screens.signup.SignUpViewModel
+import se.hkr.andriod.ui.viewmodel.AuthViewModelFactory
 
 @Composable
 fun AppNavGraph() {
@@ -20,7 +23,9 @@ fun AppNavGraph() {
         startDestination = Routes.LOGIN
     ) {
         composable(Routes.LOGIN) {
-            val loginViewModel: LoginViewModel = viewModel()
+            val context = LocalContext.current
+            val factory = remember { AuthViewModelFactory(context) }
+            val loginViewModel: LoginViewModel = viewModel(factory = factory)
 
             LoginScreen(
                 viewModel = loginViewModel,
@@ -36,7 +41,9 @@ fun AppNavGraph() {
         }
 
         composable(Routes.SIGN_UP) {
-            val registerViewModel: SignUpViewModel = viewModel()
+            val context = LocalContext.current
+            val factory = remember { AuthViewModelFactory(context) }
+            val registerViewModel: SignUpViewModel = viewModel(factory = factory)
 
             SignUpScreen(
                 viewModel = registerViewModel,

--- a/app/src/main/java/se/hkr/andriod/ui/screens/login/LoginViewModel.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/login/LoginViewModel.kt
@@ -22,7 +22,7 @@ data class LoginUiState(
 
 class LoginViewModel(
     private val connectionManager: ConnectionManager = ConnectionManager(),
-    private val authService: AuthService = AuthService()
+    private val authService: AuthService
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(LoginUiState())

--- a/app/src/main/java/se/hkr/andriod/ui/screens/signup/SignUpViewModel.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/signup/SignUpViewModel.kt
@@ -24,7 +24,7 @@ data class SignupUiState(
 
 class SignUpViewModel(
     private val connectionManager: ConnectionManager = ConnectionManager(),
-    private val authService: AuthService = AuthService()
+    private val authService: AuthService
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SignupUiState())

--- a/app/src/main/java/se/hkr/andriod/ui/viewmodel/AuthViewModelFactory.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/viewmodel/AuthViewModelFactory.kt
@@ -1,0 +1,29 @@
+package se.hkr.andriod.ui.viewmodel
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import se.hkr.andriod.data.network.AuthService
+import se.hkr.andriod.data.network.ConnectionManager
+import se.hkr.andriod.ui.screens.login.LoginViewModel
+import se.hkr.andriod.ui.screens.signup.SignUpViewModel
+
+class AuthViewModelFactory(
+    private val context: Context
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+
+        val authService = AuthService(context.applicationContext)
+        val connectionManager = ConnectionManager()
+
+        return when {
+            modelClass.isAssignableFrom(LoginViewModel::class.java) -> {
+                LoginViewModel(connectionManager, authService) as T
+            }
+            modelClass.isAssignableFrom(SignUpViewModel::class.java) -> {
+                SignUpViewModel(connectionManager, authService) as T
+            }
+            else -> throw IllegalArgumentException("Unknown ViewModel class")
+        }
+    }
+}


### PR DESCRIPTION
Add PersistentCookieJar for storing cookies across app restarts
Add NetworkModule to provide shared OkHttpClient instance
Add AuthViewModelFactory as a factory for auth related viewmodels. Using the ViewModelFactory in NavGraph for the login and signup viewmodels. Update AuthService to use the shared okhttp client.