### PR TITLE
70 automatic backend connection

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,6 +56,7 @@ dependencies {
     implementation(libs.androidx.compose.foundation)
     implementation(libs.androidx.datastore.core)
     implementation(libs.androidx.appcompat)
+    implementation(libs.androidx.compose.runtime)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/se/hkr/andriod/data/network/AuthService.kt
+++ b/app/src/main/java/se/hkr/andriod/data/network/AuthService.kt
@@ -7,7 +7,7 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import org.json.JSONObject
 import java.io.IOException
 
-class AuthService(context: Context) {
+class AuthService(private val context: Context) {
     private val client = NetworkModule.getClient(context)
 
     private fun postRequest(
@@ -66,7 +66,7 @@ class AuthService(context: Context) {
                 val jsonResponse = JSONObject(response)
                 val token = jsonResponse.getString("accessToken")
 
-                AuthSession.saveToken(token)
+                AuthSession.saveToken(context, token)
 
                 onResult(true, token)
 
@@ -100,7 +100,7 @@ class AuthService(context: Context) {
                 val jsonResponse = JSONObject(response)
                 val token = jsonResponse.getString("accessToken")
 
-                AuthSession.saveToken(token)
+                AuthSession.saveToken(context, token)
 
                 onResult(true, token)
 

--- a/app/src/main/java/se/hkr/andriod/data/network/AuthSession.kt
+++ b/app/src/main/java/se/hkr/andriod/data/network/AuthSession.kt
@@ -1,18 +1,30 @@
 package se.hkr.andriod.data.network
 
+import android.content.Context
+import androidx.core.content.edit
+
 object AuthSession {
     private var accessToken: String? = null
 
-    fun saveToken(token: String) {
+    fun saveToken(context: Context, token: String) {
         accessToken = token
+        val prefs = context.getSharedPreferences("auth", Context.MODE_PRIVATE)
+        prefs.edit { putString("access_token", token) }
+    }
+
+    fun loadToken(context: Context) {
+        val prefs = context.getSharedPreferences("auth", Context.MODE_PRIVATE)
+        accessToken = prefs.getString("access_token", null)
     }
 
     fun getToken(): String? {
         return accessToken
     }
 
-    fun clear() {
+    fun clear(context: Context) {
         accessToken = null
+        val prefs = context.getSharedPreferences("auth", Context.MODE_PRIVATE)
+        prefs.edit { clear() }
     }
 
     fun isLoggedIn(): Boolean {

--- a/app/src/main/java/se/hkr/andriod/navigation/AppNavGraph.kt
+++ b/app/src/main/java/se/hkr/andriod/navigation/AppNavGraph.kt
@@ -1,12 +1,14 @@
 package se.hkr.andriod.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import se.hkr.andriod.data.network.AuthSession
 import se.hkr.andriod.ui.screens.login.LoginScreen
 import se.hkr.andriod.ui.screens.login.LoginViewModel
 import se.hkr.andriod.ui.screens.main.MainScreen
@@ -17,13 +19,24 @@ import se.hkr.andriod.ui.viewmodel.AuthViewModelFactory
 @Composable
 fun AppNavGraph() {
     val navController = rememberNavController()
+    val context = LocalContext.current
+
+    // Load token once when app starts
+    LaunchedEffect(Unit) {
+        AuthSession.loadToken(context)
+
+        if (AuthSession.isLoggedIn()) {
+            navController.navigate(Routes.MAIN) {
+                popUpTo(Routes.LOGIN) { inclusive = true }
+            }
+        }
+    }
 
     NavHost(
         navController = navController,
         startDestination = Routes.LOGIN
     ) {
         composable(Routes.LOGIN) {
-            val context = LocalContext.current
             val factory = remember { AuthViewModelFactory(context) }
             val loginViewModel: LoginViewModel = viewModel(factory = factory)
 
@@ -41,7 +54,6 @@ fun AppNavGraph() {
         }
 
         composable(Routes.SIGN_UP) {
-            val context = LocalContext.current
             val factory = remember { AuthViewModelFactory(context) }
             val registerViewModel: SignUpViewModel = viewModel(factory = factory)
 
@@ -61,6 +73,8 @@ fun AppNavGraph() {
         composable(Routes.MAIN) {
             MainScreen(
                 onLogout = {
+                    AuthSession.clear(context)
+
                     navController.navigate(Routes.LOGIN) {
                         popUpTo(Routes.MAIN) { inclusive = true }
                     }

--- a/app/src/main/java/se/hkr/andriod/ui/screens/main/MainScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/main/MainScreen.kt
@@ -10,6 +10,7 @@ import se.hkr.andriod.ui.screens.deviceoverview.DeviceOverviewScreen
 import se.hkr.andriod.ui.screens.settings.SettingsScreen
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -24,6 +25,7 @@ import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
 import se.hkr.andriod.data.language.LanguageStorage
+import se.hkr.andriod.data.network.AuthSession
 import se.hkr.andriod.data.network.ConnectionManager
 import se.hkr.andriod.navigation.BottomNavItem
 import se.hkr.andriod.ui.screens.adddevice.AddDeviceScreen
@@ -48,6 +50,17 @@ fun MainScreen(
     val navController = rememberNavController()
 
     val connectionManager = remember { ConnectionManager() }
+
+    LaunchedEffect(Unit) {
+        val token = AuthSession.getToken()
+        if (token != null) {
+            connectionManager.startConnection { ip ->
+                if (ip != null) {
+                    connectionManager.connectWebSocket()
+                }
+            }
+        }
+    }
 
     val items = listOf(
         BottomNavItem.Overview,

--- a/app/src/main/java/se/hkr/andriod/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/settings/SettingsScreen.kt
@@ -141,7 +141,7 @@ fun SettingsScreen(
                             val cookieJar = NetworkModule.getClient(context).cookieJar as PersistentCookieJar
 
                             fun finishLogout() {
-                                AuthSession.clear()
+                                AuthSession.clear(context)
                                 cookieJar.clear()
                                 connectionManager.disconnect()
 

--- a/app/src/main/java/se/hkr/andriod/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/settings/SettingsScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import se.hkr.andriod.R
@@ -31,7 +30,6 @@ fun SettingsScreen(
 ) {
     val context = LocalContext.current
 
-    var discoveredIp: String? by remember { mutableStateOf("Not connected") }
     var showThemeDialog by remember { mutableStateOf(false) }
 
     val devices by connectionManager.deviceStore.devices.collectAsState()
@@ -164,41 +162,6 @@ fun SettingsScreen(
                         modifier = Modifier.width(160.dp)
                     )
                 }
-            }
-
-            // Connect to Server
-            item {
-                Spacer(modifier = Modifier.height(24.dp))
-                Box(
-                    modifier = Modifier.fillMaxWidth(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    AppButton(
-                        text = "Connect to Server",
-                        onClick = {
-                            discoveredIp = "Searching..."
-                            connectionManager.startConnection { ip ->
-                                if (ip == null) {
-                                    discoveredIp = "No backend found"
-                                    return@startConnection
-                                }
-                                discoveredIp = ip
-                                connectionManager.connectWebSocket()
-                            }
-                        },
-                        modifier = Modifier.width(160.dp)
-                    )
-                }
-            }
-
-            // Backend IP display
-            item {
-                Spacer(modifier = Modifier.height(16.dp))
-                Text(
-                    text = "Backend IP: $discoveredIp",
-                    style = MaterialTheme.typography.bodyMedium,
-                    textAlign = TextAlign.Center,
-                )
             }
         }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ animationCoreLint = "1.10.2"
 foundation = "1.10.3"
 datastoreCore = "1.2.1"
 appcompat = "1.7.1"
+runtime = "1.10.6"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -32,6 +33,7 @@ androidx-compose-animation-core-lint = { group = "androidx.compose.animation", n
 androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "foundation" }
 androidx-datastore-core = { group = "androidx.datastore", name = "datastore-core", version.ref = "datastoreCore" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
+androidx-compose-runtime = { group = "androidx.compose.runtime", name = "runtime", version.ref = "runtime" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
AuthSession now persists auth token in SharedPreferences to keep user logged in across app restarts
Updated SettingsScreen and AuthService to use new token save/load functions
AppNavGraph now checks AuthSession state and skips login screen when user is already authenticated
MainScreen now performs UPD discovery and establishes WebSocket connection on app start or after login/register (if token is valid)
Removed temporary backend connection button and debug text from SettingsScreen