### PR TITLE
99 refresh token

### DIFF
--- a/app/src/main/java/se/hkr/andriod/data/network/AuthService.kt
+++ b/app/src/main/java/se/hkr/andriod/data/network/AuthService.kt
@@ -143,4 +143,44 @@ class AuthService(private val context: Context) {
             }
         })
     }
+
+    fun refresh(
+        ip: String,
+        onResult: (Boolean, String?) -> Unit
+    ) {
+        val url = "http://$ip:8081/refresh"
+
+        val request = Request.Builder()
+            .url(url)
+            .post("".toRequestBody(null)) // empty body
+            .build()
+
+        client.newCall(request).enqueue(object : Callback {
+
+            override fun onFailure(call: Call, e: IOException) {
+                onResult(false, e.message)
+            }
+
+            override fun onResponse(call: Call, response: Response) {
+                val responseBody = response.body?.string()
+
+                if (!response.isSuccessful || responseBody == null) {
+                    onResult(false, "Refresh failed")
+                    return
+                }
+
+                try {
+                    val json = JSONObject(responseBody)
+                    val newToken = json.getString("accessToken")
+
+                    AuthSession.saveToken(context, newToken)
+
+                    onResult(true, newToken)
+
+                } catch (e: Exception) {
+                    onResult(false, e.message)
+                }
+            }
+        })
+    }
 }

--- a/app/src/main/java/se/hkr/andriod/data/network/ConnectionManager.kt
+++ b/app/src/main/java/se/hkr/andriod/data/network/ConnectionManager.kt
@@ -23,6 +23,12 @@ class ConnectionManager(private val udpPort: Int = 4444) {
     // Prevent infinite refresh loops
     private var hasTriedRefresh = false
 
+    private var onAuthFailure: (() -> Unit)? = null
+
+    fun setOnAuthFailureListener(listener: () -> Unit) {
+        onAuthFailure = listener
+    }
+
     fun startConnection(onResult: (String?) -> Unit) {
         udpDiscovery.discoverServer(port = udpPort) { ip ->
             if (ip != null) {
@@ -71,10 +77,10 @@ class ConnectionManager(private val udpPort: Int = 4444) {
                         Log.d("CONNECTION", "Refresh successful, retrying connection")
 
                         AuthSession.saveToken(context, newToken)
-
                         connectWebSocket(context) // retry
                     } else {
                         Log.d("CONNECTION", "Refresh failed, user must log in again")
+                        onAuthFailure?.invoke()
                     }
                 }
             } else {

--- a/app/src/main/java/se/hkr/andriod/data/network/ConnectionManager.kt
+++ b/app/src/main/java/se/hkr/andriod/data/network/ConnectionManager.kt
@@ -1,5 +1,6 @@
 package se.hkr.andriod.data.network
 
+import android.content.Context
 import android.util.Log
 
 class ConnectionManager(private val udpPort: Int = 4444) {
@@ -19,6 +20,9 @@ class ConnectionManager(private val udpPort: Int = 4444) {
     private var isListening = false
     private var backendIp: String? = null
 
+    // Prevent infinite refresh loops
+    private var hasTriedRefresh = false
+
     fun startConnection(onResult: (String?) -> Unit) {
         udpDiscovery.discoverServer(port = udpPort) { ip ->
             if (ip != null) {
@@ -34,15 +38,51 @@ class ConnectionManager(private val udpPort: Int = 4444) {
     }
 
     // Connect WebSocket automatically
-    fun connectWebSocket() {
+    fun connectWebSocket(context: Context) {
         val ip = backendIp ?: run {
             Log.d("CONNECTION", "No backend IP available")
             return
         }
 
+        val token = AuthSession.getToken()
+
+        if (token == null) {
+            Log.d("CONNECTION", "No token available, cannot connect")
+            return
+        }
+
+        Log.d("CONNECTION", "Connecting WebSocket with token")
+
         webSocketManager.connect(ip)
 
-        // Start listening to messages if not already
+        // Failure message listener
+        webSocketManager.setOnFailureListener {
+            Log.d("CONNECTION", "WebSocket failed")
+
+            if (!hasTriedRefresh) {
+                Log.d("CONNECTION", "Trying refresh...")
+
+                hasTriedRefresh = true
+
+                val authService = AuthService(context)
+
+                authService.refresh(ip) { success, newToken ->
+                    if (success && newToken != null) {
+                        Log.d("CONNECTION", "Refresh successful, retrying connection")
+
+                        AuthSession.saveToken(context, newToken)
+
+                        connectWebSocket(context) // retry
+                    } else {
+                        Log.d("CONNECTION", "Refresh failed, user must log in again")
+                    }
+                }
+            } else {
+                Log.d("CONNECTION", "Already tried refresh, giving up")
+            }
+        }
+
+        // Normal message listener
         if (!isListening) {
             webSocketManager.addMessageListener { message ->
                 Log.d("CONNECTION", "Received message: $message")
@@ -66,6 +106,7 @@ class ConnectionManager(private val udpPort: Int = 4444) {
         Log.d("CONNECTION", "Disconnecting from backend")
         webSocketManager.disconnect()
         isListening = false
+        hasTriedRefresh = false // reset for next session
     }
 
     fun getBackendIp(): String? {

--- a/app/src/main/java/se/hkr/andriod/data/network/WebSocketManager.kt
+++ b/app/src/main/java/se/hkr/andriod/data/network/WebSocketManager.kt
@@ -10,6 +10,12 @@ class WebSocketManager {
 
     private val messageListeners = mutableListOf<(String) -> Unit>()
 
+    private var onFailureListener: (() -> Unit)? = null
+
+    fun setOnFailureListener(listener: () -> Unit) {
+        onFailureListener = listener
+    }
+
     fun connect(ip: String, port: Int = 8080) {
 
         val token = AuthSession.getToken()
@@ -37,14 +43,18 @@ class WebSocketManager {
 
             override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
                 Log.d("WEBSOCKET", "Closing: $code / $reason")
+                webSocket.close(1000, null)
+                onFailureListener?.invoke()
             }
 
             override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
                 Log.d("WEBSOCKET", "Closed: $code / $reason")
+                onFailureListener?.invoke()
             }
 
             override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
                 Log.d("WEBSOCKET", "Failure: ${t.message}")
+                onFailureListener?.invoke()
             }
         })
     }

--- a/app/src/main/java/se/hkr/andriod/ui/screens/main/MainScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/main/MainScreen.kt
@@ -50,13 +50,14 @@ fun MainScreen(
     val navController = rememberNavController()
 
     val connectionManager = remember { ConnectionManager() }
+    val context = LocalContext.current
 
     LaunchedEffect(Unit) {
         val token = AuthSession.getToken()
         if (token != null) {
             connectionManager.startConnection { ip ->
                 if (ip != null) {
-                    connectionManager.connectWebSocket()
+                    connectionManager.connectWebSocket(context)
                 }
             }
         }

--- a/app/src/main/java/se/hkr/andriod/ui/screens/main/MainScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/main/MainScreen.kt
@@ -27,6 +27,8 @@ import androidx.navigation.navArgument
 import se.hkr.andriod.data.language.LanguageStorage
 import se.hkr.andriod.data.network.AuthSession
 import se.hkr.andriod.data.network.ConnectionManager
+import se.hkr.andriod.data.network.NetworkModule
+import se.hkr.andriod.data.network.PersistentCookieJar
 import se.hkr.andriod.navigation.BottomNavItem
 import se.hkr.andriod.ui.screens.adddevice.AddDeviceScreen
 import se.hkr.andriod.ui.screens.devicecard.DeviceHostScreen
@@ -59,6 +61,23 @@ fun MainScreen(
                 if (ip != null) {
                     connectionManager.connectWebSocket(context)
                 }
+            }
+        }
+    }
+
+    // Force logout in auth failure (if token refresh fails)
+    LaunchedEffect(Unit) {
+        connectionManager.setOnAuthFailureListener {
+            android.util.Log.d("AUTH", "Auth failed, forcing logout")
+
+            val cookieJar = NetworkModule.getClient(context).cookieJar as PersistentCookieJar
+
+            AuthSession.clear(context)
+            cookieJar.clear()
+            connectionManager.disconnect()
+
+            android.os.Handler(android.os.Looper.getMainLooper()).post {
+                onLogout() // navigate back to login
             }
         }
     }


### PR DESCRIPTION
Added refresh route in AuthService to refresh auth token via backend
Added onFailureListener to WebSocketManager to detect backend connection failures
Connected WebSocket failure handling with AuthService token refresh logic for automatic recovery on failure
Added onAuthFailure handler in ConnectionManager to trigger logout and redirect to login if token refresh fails
Cleared cookies and local storage on authentication failure during refresh process