### PR TITLE
51 settings   rooms functionality

### DIFF
--- a/app/src/main/java/se/hkr/andriod/data/network/MessageRouter.kt
+++ b/app/src/main/java/se/hkr/andriod/data/network/MessageRouter.kt
@@ -9,7 +9,7 @@ import org.json.JSONObject
 class MessageRouter(
     private val deviceStore: DeviceStore,
     private val userStore: UserStore,
-    private val RoomStore: RoomStore,
+    private val roomStore: RoomStore,
     private val actionHandler: ActionResponseHandler
 ) {
     private val scope = CoroutineScope(Dispatchers.Main)
@@ -28,6 +28,9 @@ class MessageRouter(
 
                 // User messages
                 "users" -> userStore.handleMessage(json)
+
+                // Room messages
+                "rooms" -> roomStore.handleMessage(json)
 
                 // Action response
                 "action response" -> {

--- a/app/src/main/java/se/hkr/andriod/data/network/MessageRouter.kt
+++ b/app/src/main/java/se/hkr/andriod/data/network/MessageRouter.kt
@@ -9,6 +9,7 @@ import org.json.JSONObject
 class MessageRouter(
     private val deviceStore: DeviceStore,
     private val userStore: UserStore,
+    private val RoomStore: RoomStore,
     private val actionHandler: ActionResponseHandler
 ) {
     private val scope = CoroutineScope(Dispatchers.Main)

--- a/app/src/main/java/se/hkr/andriod/data/network/RoomStore.kt
+++ b/app/src/main/java/se/hkr/andriod/data/network/RoomStore.kt
@@ -6,11 +6,10 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import org.json.JSONObject
+import se.hkr.andriod.domain.model.device.Room
+import kotlin.collections.filter
+import kotlin.collections.map
 
-data class Room(
-    val id: String,
-    val name: String
-)
 
 class RoomStore(private val webSocketManager: WebSocketManager) {
 

--- a/app/src/main/java/se/hkr/andriod/data/network/RoomStore.kt
+++ b/app/src/main/java/se/hkr/andriod/data/network/RoomStore.kt
@@ -4,6 +4,7 @@ import android.R.id.message
 import android.util.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -87,6 +88,8 @@ class RoomStore(private val webSocketManager: WebSocketManager) {
 
         scope.launch {
             _rooms.value += newRoom
+            delay(300)
+            getRooms()
         }
     }
 

--- a/app/src/main/java/se/hkr/andriod/data/network/RoomStore.kt
+++ b/app/src/main/java/se/hkr/andriod/data/network/RoomStore.kt
@@ -1,5 +1,7 @@
 package se.hkr.andriod.data.network
 
+import android.R.id.message
+import android.util.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -17,6 +19,42 @@ class RoomStore(private val webSocketManager: WebSocketManager) {
     val rooms: StateFlow<List<Room>> get() = _rooms
 
     private val scope = CoroutineScope(Dispatchers.Main)
+
+    fun handleMessage(json: JSONObject) {
+        try {
+            val type = json.getString("type")
+            val payload = json.getJSONObject("payload")
+
+            when (type.lowercase()) {
+                "rooms" -> handleRooms(payload)
+                else -> Log.d("ROOMSTORE", "Unhandled message type: $type")
+            }
+        } catch (e: Exception) {
+            Log.e("ROOMSTORE", "Failed to parse message: $message", e)
+        }
+    }
+
+    private fun handleRooms(payload: JSONObject) {
+        try {
+            val roomsJsonArray = payload.getJSONArray("rooms")
+            val roomsList = mutableListOf<Room>()
+
+            for (i in 0 until roomsJsonArray.length()) {
+                val roomObj = roomsJsonArray.getJSONObject(i)
+                val room = Room(
+                    id = roomObj.getString("id"),
+                    name = roomObj.getString("name")
+                )
+                roomsList.add(room)
+            }
+
+            scope.launch {
+                _rooms.value = roomsList
+            }
+        } catch (e: Exception) {
+            Log.e("ROOMSTORE", "Failed to parse rooms payload", e)
+        }
+    }
 
     // Get rooms
     fun getRooms() {

--- a/app/src/main/java/se/hkr/andriod/ui/screens/deviceoverview/DeviceOverviewScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/deviceoverview/DeviceOverviewScreen.kt
@@ -29,6 +29,7 @@ import se.hkr.andriod.data.network.ConnectionManager
 import se.hkr.andriod.navigation.Routes
 import se.hkr.andriod.ui.components.AppTextField
 import se.hkr.andriod.ui.components.DeviceCardItem
+import se.hkr.andriod.ui.screens.main.goToRooms
 import se.hkr.andriod.ui.theme.cardBackground
 
 @Composable
@@ -149,7 +150,10 @@ fun DeviceOverviewScreen(
                         showAddSheet = false
                         navController.navigate(Routes.SCAN)
                     },
-                    onCreateRoomClick = { /* TODO: implement create room */ }
+                    onCreateRoomClick = {
+                        showAddSheet = false
+                        navController.goToRooms()
+                    }
                 )
             }
 

--- a/app/src/main/java/se/hkr/andriod/ui/screens/main/MainScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/main/MainScreen.kt
@@ -42,6 +42,8 @@ import se.hkr.andriod.ui.screens.settings.subscreens.devices.DevicesScreen
 import se.hkr.andriod.ui.screens.settings.subscreens.devices.DevicesViewModel
 import se.hkr.andriod.ui.screens.settings.subscreens.devices.DevicesViewModelFactory
 import se.hkr.andriod.ui.screens.settings.subscreens.language.LanguageViewModel
+import se.hkr.andriod.ui.screens.settings.subscreens.rooms.RoomsViewModel
+import se.hkr.andriod.ui.screens.settings.subscreens.rooms.RoomsViewModelFactory
 import se.hkr.andriod.ui.theme.cardBackground
 import se.hkr.andriod.ui.theme.lightBlue
 
@@ -202,8 +204,8 @@ fun MainScreen(
                     viewModel = viewModel(),
                     onBackClick = { navController.navigateUp() }
                 ) }
-                composable(Routes.DEVICES) {
 
+                composable(Routes.DEVICES) {
                     val viewModel: DevicesViewModel = viewModel(
                         factory = DevicesViewModelFactory(connectionManager.deviceStore)
                     )
@@ -213,13 +215,22 @@ fun MainScreen(
                         onBackClick = { navController.navigateUp() }
                     )
                 }
+
                 composable(Routes.ROOMS) {
+                    val viewModel: RoomsViewModel = viewModel(
+                        factory = RoomsViewModelFactory(
+                            connectionManager.roomStore, connectionManager.deviceStore
+                        )
+                    )
+
                     RoomsScreen(
-                        viewModel = viewModel(),
+                        viewModel = viewModel,
                         onBackClick = { navController.navigateUp() }
                     )
                 }
+
                 composable(Routes.SCHEDULES) { SchedulesScreen() }
+
                 composable(Routes.LANGUAGE) {
                     val context = LocalContext.current.applicationContext
 
@@ -234,6 +245,7 @@ fun MainScreen(
                         onBackClick = { navController.navigateUp() }
                     )
                 }
+
                 composable(Routes.ACCOUNT) { AccountInfoScreen(
                     viewModel = viewModel(),
                     onBackClick = { navController.navigateUp() }

--- a/app/src/main/java/se/hkr/andriod/ui/screens/main/NavExtensions.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/main/NavExtensions.kt
@@ -1,0 +1,19 @@
+package se.hkr.andriod.ui.screens.main
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import se.hkr.andriod.navigation.BottomNavItem
+import se.hkr.andriod.navigation.Routes
+
+fun NavController.goToRooms() {
+    // Switch to Settings tab
+    navigate(BottomNavItem.Settings.route) {
+        popUpTo(graph.findStartDestination().id) {
+            saveState = true
+        }
+        launchSingleTop = true
+        restoreState = true
+    }
+    // Then go to Rooms screen
+    navigate(Routes.ROOMS)
+}

--- a/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/rooms/RoomsScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/rooms/RoomsScreen.kt
@@ -61,118 +61,122 @@ fun RoomsScreen(
             .background(MaterialTheme.colorScheme.lightBlue)
             .padding(top = 24.dp)
     ) {
-        Column(
+        LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(vertical = 24.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            CustomScreenHeader(
-                title = stringResource(R.string.rooms),
-                onBackClick = onBackClick
-            )
-
-            // Room Selector
-            Card(
-                modifier = Modifier.fillMaxWidth(0.9f),
-                shape = RoundedCornerShape(16.dp),
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.cardBackground
+            item {
+                CustomScreenHeader(
+                    title = stringResource(R.string.rooms),
+                    onBackClick = onBackClick
                 )
-            ) {
-                Column(
-                    modifier = Modifier.padding(20.dp)
-                ) {
-                    Text(
-                        text = stringResource(R.string.room),
-                        style = MaterialTheme.typography.titleMedium
+            }
+
+            item {
+                Card(
+                    modifier = Modifier.fillMaxWidth(0.9f),
+                    shape = RoundedCornerShape(16.dp),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.cardBackground
                     )
+                ) {
+                    Column(modifier = Modifier.padding(20.dp)) {
 
-                    Spacer(modifier = Modifier.height(16.dp))
-
-                    ExposedDropdownMenuBox(
-                        expanded = expanded,
-                        onExpandedChange = { expanded = !expanded }
-                    ) {
-                        OutlinedTextField(
-                            value = uiState.selectedRoom,
-                            onValueChange = {},
-                            readOnly = true,
-                            modifier = Modifier
-                                .menuAnchor()
-                                .fillMaxWidth(),
-                            trailingIcon = {
-                                ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
-                            },
-                            shape = RoundedCornerShape(12.dp),
-                            singleLine = true
+                        Text(
+                            text = stringResource(R.string.room),
+                            style = MaterialTheme.typography.titleMedium
                         )
 
-                        ExposedDropdownMenu(
+                        Spacer(modifier = Modifier.height(16.dp))
+
+                        ExposedDropdownMenuBox(
                             expanded = expanded,
-                            onDismissRequest = { expanded = false }
+                            onExpandedChange = { expanded = !expanded }
                         ) {
-                            uiState.rooms.forEach { room ->
-                                DropdownMenuItem(
-                                    text = { Text(room) },
-                                    onClick = {
-                                        viewModel.onRoomSelected(room)
-                                        expanded = false
-                                    }
-                                )
+
+                            OutlinedTextField(
+                                value = uiState.selectedRoom?.name ?: "",
+                                onValueChange = {},
+                                readOnly = true,
+                                modifier = Modifier
+                                    .menuAnchor()
+                                    .fillMaxWidth(),
+                                trailingIcon = {
+                                    ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
+                                },
+                                shape = RoundedCornerShape(12.dp),
+                                singleLine = true
+                            )
+
+                            ExposedDropdownMenu(
+                                expanded = expanded,
+                                onDismissRequest = { expanded = false }
+                            ) {
+                                uiState.rooms.forEach { room ->
+                                    DropdownMenuItem(
+                                        text = { Text(room.name) },
+                                        onClick = {
+                                            viewModel.onRoomSelected(room)
+                                            expanded = false
+                                        }
+                                    )
+                                }
                             }
                         }
-                    }
 
-                    Spacer(modifier = Modifier.height(12.dp))
+                        Spacer(modifier = Modifier.height(12.dp))
 
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        IconButton(onClick = { viewModel.showCreateDialog() }) {
-                            Icon(Icons.Rounded.Add, contentDescription = null)
-                        }
-                        IconButton(onClick = { viewModel.showRenameDialog() }) {
-                            Icon(Icons.Rounded.Edit, contentDescription = null)
-                        }
-                        IconButton(onClick = { viewModel.showDeleteDialog() }) {
-                            Icon(Icons.Rounded.Delete, contentDescription = null)
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+
+                            IconButton(onClick = { viewModel.showCreateDialog() }) {
+                                Icon(Icons.Rounded.Add, contentDescription = null)
+                            }
+
+                            IconButton(onClick = { viewModel.showRenameDialog() }) {
+                                Icon(Icons.Rounded.Edit, contentDescription = null)
+                            }
+
+                            IconButton(onClick = { viewModel.showDeleteDialog() }) {
+                                Icon(Icons.Rounded.Delete, contentDescription = null)
+                            }
                         }
                     }
                 }
             }
 
-            Spacer(modifier = Modifier.height(16.dp))
+            item { Spacer(modifier = Modifier.height(16.dp)) }
 
-            // Devices in room
-            Card(
-                modifier = Modifier.fillMaxWidth(0.9f),
-                shape = RoundedCornerShape(16.dp),
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.cardBackground
-                )
-            ) {
-                Column(
-                    modifier = Modifier.padding(20.dp)
-                ) {
-                    Text(
-                        text = stringResource(R.string.devices_in_room),
-                        style = MaterialTheme.typography.titleMedium
+            item {
+                Card(
+                    modifier = Modifier.fillMaxWidth(0.9f),
+                    shape = RoundedCornerShape(16.dp),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.cardBackground
                     )
+                ) {
+                    Column(modifier = Modifier.padding(20.dp)) {
 
-                    Spacer(modifier = Modifier.height(12.dp))
+                        Text(
+                            text = stringResource(R.string.devices_in_room),
+                            style = MaterialTheme.typography.titleMedium
+                        )
 
-                    LazyColumn {
-                        items(uiState.devicesInRoom) { device ->
+                        Spacer(modifier = Modifier.height(12.dp))
+
+                        uiState.devicesInRoom.forEach { device ->
                             Row(
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .padding(vertical = 8.dp),
                                 horizontalArrangement = Arrangement.SpaceBetween,
                             ) {
-                                Text(device)
+                                Text(device.name ?: "")
 
-                                TextButton(onClick = { /* Remove Device from room */ }) {
+                                TextButton(onClick = {
+                                    viewModel.removeDeviceFromRoom(device)
+                                }) {
                                     Text(stringResource(R.string.remove))
                                 }
                             }
@@ -181,43 +185,46 @@ fun RoomsScreen(
                 }
             }
 
-            Spacer(modifier = Modifier.height(16.dp))
+            item { Spacer(modifier = Modifier.height(16.dp)) }
 
-            // Add Device to the room
-            Card(
-                modifier = Modifier.fillMaxWidth(0.9f),
-                shape = RoundedCornerShape(16.dp),
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.cardBackground
-                )
-            ) {
-                Column(
-                    modifier = Modifier.padding(20.dp)
-                ) {
-                    Text(
-                        text = stringResource(R.string.add_device_to_room),
-                        style = MaterialTheme.typography.titleMedium
+            item {
+                Card(
+                    modifier = Modifier.fillMaxWidth(0.9f),
+                    shape = RoundedCornerShape(16.dp),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.cardBackground
                     )
+                ) {
+                    Column(modifier = Modifier.padding(20.dp)) {
 
-                    Spacer(modifier = Modifier.height(12.dp))
+                        Text(
+                            text = stringResource(R.string.add_device_to_room),
+                            style = MaterialTheme.typography.titleMedium
+                        )
 
-                    uiState.availableDevices.forEach { device ->
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(vertical = 8.dp),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                        ) {
-                            Text(device)
+                        Spacer(modifier = Modifier.height(12.dp))
 
-                            TextButton(onClick = { /* Add Device to room */ }) {
-                                Text(stringResource(R.string.add_device_to_room))
+                        uiState.availableDevices.forEach { device ->
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = 8.dp),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                            ) {
+                                Text(device.name ?: "")
+
+                                TextButton(onClick = {
+                                    viewModel.addDeviceToRoom(device)
+                                }) {
+                                    Text(stringResource(R.string.add_device_to_room))
+                                }
                             }
                         }
                     }
                 }
             }
         }
+
         if (uiState.showCreateDialog) {
             InputDialog(
                 title = stringResource(R.string.create_room),
@@ -227,8 +234,8 @@ fun RoomsScreen(
                 confirmText = stringResource(R.string.create),
                 dismissText = stringResource(R.string.cancel),
                 onConfirm = {
+                    viewModel.createRoom()
                     viewModel.dismissDialogs()
-                    // create room
                 },
                 onDismiss = viewModel::dismissDialogs
             )
@@ -243,8 +250,8 @@ fun RoomsScreen(
                 confirmText = stringResource(R.string.rename),
                 dismissText = stringResource(R.string.cancel),
                 onConfirm = {
+                    viewModel.renameRoom()
                     viewModel.dismissDialogs()
-                    // rename room
                 },
                 onDismiss = viewModel::dismissDialogs
             )
@@ -257,12 +264,11 @@ fun RoomsScreen(
                 confirmText = stringResource(R.string.delete),
                 dismissText = stringResource(R.string.cancel),
                 onConfirm = {
+                    viewModel.deleteRoom()
                     viewModel.dismissDialogs()
-                    // delete room
                 },
                 onDismiss = viewModel::dismissDialogs
             )
         }
-
     }
 }

--- a/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/rooms/RoomsScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/rooms/RoomsScreen.kt
@@ -172,7 +172,7 @@ fun RoomsScreen(
                                     .padding(vertical = 8.dp),
                                 horizontalArrangement = Arrangement.SpaceBetween,
                             ) {
-                                Text(device.name ?: "")
+                                Text(device.displayName)
 
                                 TextButton(onClick = {
                                     viewModel.removeDeviceFromRoom(device)
@@ -211,7 +211,7 @@ fun RoomsScreen(
                                     .padding(vertical = 8.dp),
                                 horizontalArrangement = Arrangement.SpaceBetween,
                             ) {
-                                Text(device.name ?: "")
+                                Text(device.displayName)
 
                                 TextButton(onClick = {
                                     viewModel.addDeviceToRoom(device)

--- a/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/rooms/RoomsScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/rooms/RoomsScreen.kt
@@ -260,7 +260,10 @@ fun RoomsScreen(
         if (uiState.showDeleteDialog) {
             ConfirmDialog(
                 title = stringResource(R.string.delete_room),
-                message = stringResource(R.string.delete_confirmation_with_name),
+                message = stringResource(
+                    R.string.delete_confirmation_with_name,
+                    uiState.selectedRoom?.name ?: ""
+                ),
                 confirmText = stringResource(R.string.delete),
                 dismissText = stringResource(R.string.cancel),
                 onConfirm = {

--- a/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/rooms/RoomsViewModel.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/rooms/RoomsViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
+import se.hkr.andriod.data.network.DeviceStore
+import se.hkr.andriod.data.network.RoomStore
 
 // Currently only mock data, will change
 data class RoomsUiState(
@@ -31,7 +33,10 @@ data class RoomsUiState(
 
 )
 
-class RoomsViewModel : ViewModel() {
+class RoomsViewModel(
+    private val roomStore: RoomStore,
+    private val deviceStore: DeviceStore
+) : ViewModel() {
 
     private val _uiState = MutableStateFlow(RoomsUiState())
     val uiState: StateFlow<RoomsUiState> = _uiState

--- a/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/rooms/RoomsViewModel.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/rooms/RoomsViewModel.kt
@@ -41,7 +41,7 @@ class RoomsViewModel(
         viewModelScope.launch {
             roomStore.rooms.collect { rooms ->
                 _uiState.update { state ->
-                    val selected = state.selectedRoom ?: rooms.firstOrNull()
+                    val selected = rooms.find { it.id == state.selectedRoom?.id } ?: rooms.firstOrNull()
                     val inRoom = state.allDevices.filter { it.room == selected?.name }
                     val available = state.allDevices.filter { it.room != selected?.name }
 
@@ -115,12 +115,37 @@ class RoomsViewModel(
         }
     }
 
-    // TODO
-    fun createRoom() {}
+    fun createRoom() {
+        val name = _uiState.value.inputText.trim()
+        if (name.isBlank()) return
 
-    fun renameRoom() {}
+        viewModelScope.launch {
+            roomStore.createRoom(name)
+            dismissDialogs()
+        }
+    }
 
-    fun deleteRoom() {}
+    fun renameRoom() {
+        val state = _uiState.value
+        val room = state.selectedRoom ?: return
+        val newName = state.inputText.trim()
+
+        if (newName.isBlank()) return
+
+        viewModelScope.launch {
+            roomStore.updateRoomName(room.id, newName)
+            dismissDialogs()
+        }
+    }
+
+    fun deleteRoom() {
+        val room = _uiState.value.selectedRoom ?: return
+
+        viewModelScope.launch {
+            roomStore.deleteRoom(room.id)
+            dismissDialogs()
+        }
+    }
 
     // TODO: implement when backend supports adding/removing devices to/from rooms
     fun addDeviceToRoom(device: Device) {}

--- a/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/rooms/RoomsViewModel.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/rooms/RoomsViewModel.kt
@@ -1,36 +1,26 @@
 package se.hkr.andriod.ui.screens.settings.subscreens.rooms
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import se.hkr.andriod.data.network.DeviceStore
 import se.hkr.andriod.data.network.RoomStore
+import se.hkr.andriod.domain.model.device.Device
+import se.hkr.andriod.domain.model.device.Room
 
-// Currently only mock data, will change
 data class RoomsUiState(
-    val rooms: List<String> = listOf(
-        "Living Room",
-        "Bedroom"
-    ),
-    val selectedRoom: String = "Living Room",
-
-    val devicesInRoom: List<String> = listOf(
-        "Living Room Light",
-        "Door Lock"
-    ),
-
-    val availableDevices: List<String> = listOf(
-        "New Light",
-        "New Lock"
-    ),
-
+    val rooms: List<Room> = emptyList(),
+    val selectedRoom: Room? = null,
+    val allDevices: List<Device> = emptyList(),
+    val devicesInRoom: List<Device> = emptyList(),
+    val availableDevices: List<Device> = emptyList(),
     val showCreateDialog: Boolean = false,
     val showRenameDialog: Boolean = false,
     val showDeleteDialog: Boolean = false,
-
     val inputText: String = ""
-
 )
 
 class RoomsViewModel(
@@ -41,29 +31,77 @@ class RoomsViewModel(
     private val _uiState = MutableStateFlow(RoomsUiState())
     val uiState: StateFlow<RoomsUiState> = _uiState
 
-    fun onRoomSelected(room: String) {
-        _uiState.value = _uiState.value.copy(selectedRoom = room)
+    init {
+        roomStore.getRooms()
+        deviceStore.fetchAllDeviceInfo()
+        observeStores()
     }
 
+    private fun observeStores() {
+        viewModelScope.launch {
+            roomStore.rooms.collect { rooms ->
+                _uiState.update { state ->
+                    val selected = state.selectedRoom ?: rooms.firstOrNull()
+                    val inRoom = state.allDevices.filter { it.room == selected?.name }
+                    val available = state.allDevices.filter { it.room != selected?.name }
+
+                    state.copy(
+                        rooms = rooms,
+                        selectedRoom = selected,
+                        devicesInRoom = inRoom,
+                        availableDevices = available
+                    )
+                }
+            }
+        }
+
+        viewModelScope.launch {
+            deviceStore.allDevices.collect { devices ->
+                _uiState.update { state ->
+                    val room = state.selectedRoom
+                    state.copy(
+                        allDevices = devices,
+                        devicesInRoom = devices.filter { it.room == room?.name },
+                        availableDevices = devices.filter { it.room != room?.name }
+                    )
+                }
+            }
+        }
+    }
+
+    fun onRoomSelected(room: Room) {
+        _uiState.update { state ->
+            state.copy(
+                selectedRoom = room,
+                devicesInRoom = state.allDevices.filter { it.room == room.name },
+                availableDevices = state.allDevices.filter { it.room != room.name }
+            )
+        }
+    }
+
+    fun devicesInSelectedRoom(): List<Device> = _uiState.value.devicesInRoom
+
+    fun availableDevices(): List<Device> = _uiState.value.availableDevices
+
     fun onInputChanged(value: String) {
-        _uiState.value = _uiState.value.copy(inputText = value)
+        _uiState.update { it.copy(inputText = value) }
     }
 
     fun showCreateDialog() {
-        _uiState.value = _uiState.value.copy(showCreateDialog = true, inputText = "")
+        _uiState.update { it.copy(showCreateDialog = true, inputText = "") }
     }
 
     fun showRenameDialog() {
         _uiState.update {
             it.copy(
                 showRenameDialog = true,
-                inputText = it.selectedRoom ?: ""
+                inputText = it.selectedRoom?.name ?: ""
             )
         }
     }
 
     fun showDeleteDialog() {
-        _uiState.value = _uiState.value.copy(showDeleteDialog = true)
+        _uiState.update { it.copy(showDeleteDialog = true) }
     }
 
     fun dismissDialogs() {
@@ -76,4 +114,16 @@ class RoomsViewModel(
             )
         }
     }
+
+    // TODO
+    fun createRoom() {}
+
+    fun renameRoom() {}
+
+    fun deleteRoom() {}
+
+    // TODO: implement when backend supports adding/removing devices to/from rooms
+    fun addDeviceToRoom(device: Device) {}
+
+    fun removeDeviceFromRoom(device: Device) {}
 }

--- a/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/rooms/RoomsViewModelFactory.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/rooms/RoomsViewModelFactory.kt
@@ -1,0 +1,20 @@
+package se.hkr.andriod.ui.screens.settings.subscreens.rooms
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import se.hkr.andriod.data.network.DeviceStore
+import se.hkr.andriod.data.network.RoomStore
+
+class RoomsViewModelFactory(
+    private val roomStore: RoomStore,
+    private val deviceStore: DeviceStore
+) : ViewModelProvider.Factory {
+
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(RoomsViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return RoomsViewModel(roomStore, deviceStore) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}


### PR DESCRIPTION
Fixed missing roomStore argument in MessageRouter
Added RoomsViewModelFactory to provide deviceStore and roomStore to RoomsViewModel
Updated RoomStore to use domain.model.room instead of local room model
Added handling for incoming rooms messages and storing them in RoomStore
Room screen now displays rooms and assigned devices correctly
Added create, update, and delete room functionality in RoomStore
Re-fetch rooms after creating a room to sync local and backend room IDs
Fixed confirm delete dialog to show correct room names
Fixed device names displaying correctly when empty or null
Added NavExtensions with goToRooms navigation from DeviceOverview to Settings/Rooms screen