### PR TITLE
48 settings   users permissions functionality

### DIFF
--- a/app/src/main/java/se/hkr/andriod/data/network/UserStore.kt
+++ b/app/src/main/java/se/hkr/andriod/data/network/UserStore.kt
@@ -61,11 +61,11 @@ class UserStore(private val webSocketManager: WebSocketManager) {
         webSocketManager.sendMessage(message.toString())
     }
 
-    fun updateUserRole(userId: UUID, role: String) {
+    fun updateUserRole(userName: String, role: String) {
         val message = JSONObject().apply {
             put("type", "update user role")
             put("payload", JSONObject().apply {
-                put("userId", userId.toString())
+                put("userName", userName)
                 put("role", role)
             })
         }

--- a/app/src/main/java/se/hkr/andriod/data/network/UserStore.kt
+++ b/app/src/main/java/se/hkr/andriod/data/network/UserStore.kt
@@ -7,12 +7,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import org.json.JSONObject
-
-data class User(
-    val id: String,
-    val username: String,
-    val role: String
-)
+import se.hkr.andriod.domain.model.user.User
+import se.hkr.andriod.domain.model.user.UserRole
+import java.util.UUID
 
 class UserStore(private val webSocketManager: WebSocketManager) {
 
@@ -22,11 +19,15 @@ class UserStore(private val webSocketManager: WebSocketManager) {
     private val scope = CoroutineScope(Dispatchers.Main)
 
     fun handleMessage(json: JSONObject) {
-        val type = json.getString("type").lowercase()
-        val payload = json.getJSONObject("payload")
+        try {
+            val type = json.getString("type").lowercase()
+            val payload = json.getJSONObject("payload")
 
-        when (type) {
-            "users" -> handleUsers(payload)
+            when (type) {
+                "users" -> handleUsers(payload)
+            }
+        } catch (e: Exception) {
+            Log.e("USERSTORE", "Failed to handle message", e)
         }
     }
 
@@ -37,10 +38,12 @@ class UserStore(private val webSocketManager: WebSocketManager) {
         for (i in 0 until usersJson.length()) {
             val userJson = usersJson.getJSONObject(i)
 
+            val idString = userJson.optString("id")
+
             val user = User(
-                id = userJson.optString("id"),
+                id = idString.toUUIDOrNull() ?: continue,
                 username = userJson.optString("username"),
-                role = userJson.optString("type")
+                role = UserRole.fromBackendType(userJson.optString("type"))
             )
 
             newUsers.add(user)
@@ -58,11 +61,11 @@ class UserStore(private val webSocketManager: WebSocketManager) {
         webSocketManager.sendMessage(message.toString())
     }
 
-    fun updateUserRole(username: String, role: String) {
+    fun updateUserRole(userId: UUID, role: String) {
         val message = JSONObject().apply {
             put("type", "update user role")
             put("payload", JSONObject().apply {
-                put("userName", username)
+                put("userId", userId.toString())
                 put("role", role)
             })
         }
@@ -72,11 +75,11 @@ class UserStore(private val webSocketManager: WebSocketManager) {
         fetchUsers()
     }
 
-    fun deleteUser(username: String) {
+    fun deleteUser(userId: UUID) {
         val message = JSONObject().apply {
             put("type", "delete user")
             put("payload", JSONObject().apply {
-                put("userName", username)
+                put("userId", userId.toString())
             })
         }
 
@@ -85,15 +88,23 @@ class UserStore(private val webSocketManager: WebSocketManager) {
         fetchUsers()
     }
 
-    fun addUserToDevice(userId: String, deviceId: String) {
+    fun addUserToDevice(userId: UUID, deviceId: String) {
         val message = JSONObject().apply {
             put("type", "add user to device")
             put("payload", JSONObject().apply {
-                put("userId", userId)
+                put("userId", userId.toString())
                 put("deviceId", deviceId)
             })
         }
 
         webSocketManager.sendMessage(message.toString())
+    }
+
+    private fun String.toUUIDOrNull(): UUID? {
+        return try {
+            UUID.fromString(this)
+        } catch (_: Exception) {
+            null
+        }
     }
 }

--- a/app/src/main/java/se/hkr/andriod/data/network/UserStore.kt
+++ b/app/src/main/java/se/hkr/andriod/data/network/UserStore.kt
@@ -75,11 +75,11 @@ class UserStore(private val webSocketManager: WebSocketManager) {
         fetchUsers()
     }
 
-    fun deleteUser(userId: UUID) {
+    fun deleteUser(userName: String) {
         val message = JSONObject().apply {
             put("type", "delete user")
             put("payload", JSONObject().apply {
-                put("userId", userId.toString())
+                put("userName", userName)
             })
         }
 

--- a/app/src/main/java/se/hkr/andriod/domain/model/user/UserRole.kt
+++ b/app/src/main/java/se/hkr/andriod/domain/model/user/UserRole.kt
@@ -22,4 +22,11 @@ enum class UserRole(
             }
         }
     }
+
+    fun toBackendType(): String {
+        return when (this) {
+            ADMIN -> "admin"
+            BASE -> "user"
+        }
+    }
 }

--- a/app/src/main/java/se/hkr/andriod/ui/screens/main/MainScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/main/MainScreen.kt
@@ -42,6 +42,8 @@ import se.hkr.andriod.ui.screens.settings.subscreens.devices.DevicesScreen
 import se.hkr.andriod.ui.screens.settings.subscreens.devices.DevicesViewModel
 import se.hkr.andriod.ui.screens.settings.subscreens.devices.DevicesViewModelFactory
 import se.hkr.andriod.ui.screens.settings.subscreens.language.LanguageViewModel
+import se.hkr.andriod.ui.screens.settings.subscreens.users.UsersViewModel
+import se.hkr.andriod.ui.screens.settings.subscreens.users.UsersViewModelFactory
 import se.hkr.andriod.ui.theme.cardBackground
 import se.hkr.andriod.ui.theme.lightBlue
 
@@ -198,12 +200,19 @@ fun MainScreen(
                     )
                 }
 
-                composable(Routes.USERS) { UsersScreen(
-                    viewModel = viewModel(),
-                    onBackClick = { navController.navigateUp() }
-                ) }
-                composable(Routes.DEVICES) {
+                composable(Routes.USERS) {
+                    val viewModel: UsersViewModel = viewModel(
+                        factory = UsersViewModelFactory(
+                            connectionManager.userStore, connectionManager.deviceStore
+                        )
+                    )
 
+                    UsersScreen(
+                        viewModel = viewModel,
+                        onBackClick = { navController.navigateUp() }
+                    )
+                }
+                composable(Routes.DEVICES) {
                     val viewModel: DevicesViewModel = viewModel(
                         factory = DevicesViewModelFactory(connectionManager.deviceStore)
                     )

--- a/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/users/UsersScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/users/UsersScreen.kt
@@ -213,8 +213,15 @@ fun UsersScreen(
 
                                     Spacer(Modifier.height(4.dp))
 
+                                    val typeText = stringResource(device.deviceTypeEnum.toTextRes())
+                                    val roomName = device.room
+
                                     Text(
-                                        text = stringResource(device.deviceTypeEnum.toTextRes()),
+                                        text = if (!roomName.isNullOrBlank() && roomName != "null") {
+                                            "$typeText • $roomName"
+                                        } else {
+                                            typeText
+                                        },
                                         style = MaterialTheme.typography.bodyMedium
                                     )
 

--- a/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/users/UsersScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/users/UsersScreen.kt
@@ -277,7 +277,7 @@ fun UsersScreen(
             confirmText = stringResource(R.string.delete),
             dismissText = stringResource(R.string.cancel),
             onConfirm = {
-                viewModel.deleteSelectedUser()
+                viewModel.deleteSelectedUser(selectedUser.username)
             },
             onDismiss = viewModel::dismissDialogs
         )

--- a/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/users/UsersScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/users/UsersScreen.kt
@@ -145,7 +145,7 @@ fun UsersScreen(
                         RoleSelector(
                             selectedRole = selectedUser.role,
                             onRoleSelected = { role ->
-                                viewModel.onUserRoleChanged(selectedUser.id, role)
+                                viewModel.onUserRoleChanged(selectedUser.username, role)
                             }
                         )
                     }

--- a/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/users/UsersScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/users/UsersScreen.kt
@@ -89,7 +89,7 @@ fun UsersScreen(
                 Column(Modifier.padding(20.dp)) {
 
                     Text(
-                        text = stringResource(R.string.base_user), // todo: add correct string
+                        text = stringResource(R.string.user),
                         style = MaterialTheme.typography.titleMedium
                     )
 

--- a/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/users/UsersScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/users/UsersScreen.kt
@@ -3,6 +3,7 @@ package se.hkr.andriod.ui.screens.settings.subscreens.users
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -16,31 +17,20 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Devices
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Checkbox
-import androidx.compose.material3.Divider
-import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExposedDropdownMenuBox
-import androidx.compose.material3.ExposedDropdownMenuDefaults
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.material.icons.rounded.Delete
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import se.hkr.andriod.R
+import se.hkr.andriod.domain.model.user.UserRole
 import se.hkr.andriod.ui.components.CustomScreenHeader
+import se.hkr.andriod.ui.screens.settings.components.ActionRow
+import se.hkr.andriod.ui.screens.settings.components.ConfirmDialog
 import se.hkr.andriod.ui.theme.cardBackground
 import se.hkr.andriod.ui.theme.lightBlue
 
@@ -149,12 +139,33 @@ fun UsersScreen(
                             fontWeight = FontWeight.Bold
                         )
 
-                        Spacer(Modifier.height(8.dp))
+                        Spacer(Modifier.height(12.dp))
 
-                        Text(
-                            text = stringResource(selectedUser.role.toRoleTextRes()),
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        RoleSelector(
+                            selectedRole = selectedUser.role,
+                            onRoleSelected = { role ->
+                                viewModel.onUserRoleChanged(selectedUser.id, role)
+                            }
+                        )
+                    }
+                }
+            }
+
+            // Delete user
+            item {
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(20.dp),
+                    colors = CardDefaults.cardColors(MaterialTheme.colorScheme.cardBackground)
+                ) {
+                    Column(Modifier.padding(vertical = 8.dp)) {
+
+                        ActionRow(
+                            title = "Delete User", // todo translate string
+                            icon = {
+                                Icon(Icons.Rounded.Delete, contentDescription = null)
+                            },
+                            onClick = viewModel::showDeleteUserDialog
                         )
                     }
                 }
@@ -250,6 +261,60 @@ fun UsersScreen(
                         }
                     }
                 }
+            }
+        }
+    }
+
+    // Delete dialog
+    if (uiState.showDeleteUserDialog && selectedUser != null) {
+        ConfirmDialog(
+            title = "Delete User", // todo translate string
+            message = "Are you sure you want to delete ${selectedUser.username}?", // todo translate string
+            confirmText = stringResource(R.string.delete),
+            dismissText = stringResource(R.string.cancel),
+            onConfirm = {
+                viewModel.deleteSelectedUser()
+            },
+            onDismiss = viewModel::dismissDialogs
+        )
+    }
+}
+
+
+@Composable
+fun RoleSelector(
+    selectedRole: UserRole,
+    onRoleSelected: (UserRole) -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        UserRole.entries.forEach { role ->
+
+            val selected = role == selectedRole
+
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .clip(MaterialTheme.shapes.extraLarge)
+                    .background(
+                        if (selected)
+                            MaterialTheme.colorScheme.primary
+                        else
+                            MaterialTheme.colorScheme.surfaceVariant
+                    )
+                    .clickable { onRoleSelected(role) }
+                    .padding(vertical = 6.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = role.name,
+                    color = if (selected)
+                        MaterialTheme.colorScheme.onPrimary
+                    else
+                        MaterialTheme.colorScheme.onSurface
+                )
             }
         }
     }

--- a/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/users/UsersScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/users/UsersScreen.kt
@@ -11,12 +11,11 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Devices
-import androidx.compose.material.icons.rounded.Save
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Checkbox
@@ -42,7 +41,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import se.hkr.andriod.R
 import se.hkr.andriod.ui.components.CustomScreenHeader
-import se.hkr.andriod.ui.screens.settings.components.ActionRow
 import se.hkr.andriod.ui.theme.cardBackground
 import se.hkr.andriod.ui.theme.lightBlue
 
@@ -54,27 +52,7 @@ fun UsersScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
 
-    val selectedUser = getSelectedUser(
-        users = uiState.users,
-        selectedUserId = uiState.selectedUserId
-    )
-
-    val displayedAssignedDeviceIds = selectedUser?.let {
-        getDisplayedAssignedDeviceIds(
-            user = it,
-            editedAssignments = uiState.editedAssignments,
-            savedAssignments = uiState.savedAssignments
-        )
-    }.orEmpty()
-
-    val userInfo = mapUserToInfoUi(
-        user = selectedUser,
-        displayedAssignedDeviceIds = displayedAssignedDeviceIds
-    )
-
-    val hasUnsavedChanges = selectedUser?.let {
-        viewModel.hasUnsavedChanges(it.id)
-    } ?: false
+    val selectedUser = uiState.users.find { it.id == uiState.selectedUserId }
 
     var userDropdownExpanded by remember { mutableStateOf(false) }
 
@@ -91,6 +69,7 @@ fun UsersScreen(
         ),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
+
         item {
             CustomScreenHeader(
                 title = stringResource(R.string.settings_users_devices),
@@ -98,6 +77,7 @@ fun UsersScreen(
             )
         }
 
+        // Users
         item {
             Card(
                 modifier = Modifier.fillMaxWidth(),
@@ -106,34 +86,28 @@ fun UsersScreen(
                     containerColor = MaterialTheme.colorScheme.cardBackground
                 )
             ) {
-                Column(
-                    modifier = Modifier.padding(20.dp)
-                ) {
+                Column(Modifier.padding(20.dp)) {
+
                     Text(
-                        text = stringResource(R.string.base_user),
+                        text = stringResource(R.string.base_user), // todo: add correct string
                         style = MaterialTheme.typography.titleMedium
                     )
 
-                    Spacer(modifier = Modifier.height(16.dp))
+                    Spacer(Modifier.height(16.dp))
 
                     ExposedDropdownMenuBox(
                         expanded = userDropdownExpanded,
-                        onExpandedChange = { expanded ->
-                            userDropdownExpanded = expanded
-                        }
+                        onExpandedChange = { userDropdownExpanded = it }
                     ) {
                         OutlinedTextField(
                             value = selectedUser?.username.orEmpty(),
                             onValueChange = {},
                             readOnly = true,
-                            singleLine = true,
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .menuAnchor(),
                             trailingIcon = {
-                                ExposedDropdownMenuDefaults.TrailingIcon(
-                                    expanded = userDropdownExpanded
-                                )
+                                ExposedDropdownMenuDefaults.TrailingIcon(userDropdownExpanded)
                             },
                             shape = RoundedCornerShape(14.dp)
                         )
@@ -157,6 +131,7 @@ fun UsersScreen(
             }
         }
 
+        // User info
         if (selectedUser != null) {
             item {
                 Card(
@@ -166,37 +141,26 @@ fun UsersScreen(
                         containerColor = MaterialTheme.colorScheme.cardBackground
                     )
                 ) {
-                    Column(
-                        modifier = Modifier.padding(20.dp)
-                    ) {
+                    Column(Modifier.padding(20.dp)) {
+
                         Text(
-                            text = userInfo.name,
+                            text = selectedUser.username,
                             style = MaterialTheme.typography.headlineSmall,
                             fontWeight = FontWeight.Bold
                         )
 
-                        Spacer(modifier = Modifier.height(8.dp))
+                        Spacer(Modifier.height(8.dp))
 
                         Text(
-                            text = stringResource(userInfo.roleRes),
+                            text = stringResource(selectedUser.role.toRoleTextRes()),
                             style = MaterialTheme.typography.bodyLarge,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-
-                        Spacer(modifier = Modifier.height(6.dp))
-
-                        Text(
-                            text = stringResource(
-                                R.string.assigned_devices_count,
-                                userInfo.assignedDeviceCount
-                            ),
-                            style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                     }
                 }
             }
 
+            // Devices
             item {
                 Card(
                     modifier = Modifier.fillMaxWidth(),
@@ -205,18 +169,12 @@ fun UsersScreen(
                         containerColor = MaterialTheme.colorScheme.cardBackground
                     )
                 ) {
-                    Column(
-                        modifier = Modifier.padding(20.dp)
-                    ) {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(10.dp)
-                        ) {
-                            Icon(
-                                imageVector = Icons.Rounded.Devices,
-                                contentDescription = null,
-                                modifier = Modifier.size(22.dp)
-                            )
+                    Column(Modifier.padding(20.dp)) {
+
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Icon(Icons.Rounded.Devices, contentDescription = null)
+
+                            Spacer(Modifier.width(10.dp))
 
                             Text(
                                 text = stringResource(R.string.assigned_devices),
@@ -225,115 +183,64 @@ fun UsersScreen(
                             )
                         }
 
-                        Spacer(modifier = Modifier.height(16.dp))
+                        Spacer(Modifier.height(16.dp))
 
-                        if (uiState.devices.isEmpty()) {
-                            Text(
-                                text = stringResource(R.string.no_devices_available),
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        } else {
-                            uiState.devices.forEachIndexed { index, device ->
-                                val isAssigned = device.id in displayedAssignedDeviceIds
-                                val roomName = resolveRoomName(device.room)
-                                val description = device.displayDescription()
+                        uiState.devices.forEachIndexed { index, device ->
 
-                                Row(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .clickable {
-                                            viewModel.onDeviceToggled(
-                                                selectedUser.id,
-                                                device.id
-                                            )
-                                        }
-                                        .padding(vertical = 12.dp),
-                                    verticalAlignment = Alignment.CenterVertically
-                                ) {
-                                    Column(
-                                        modifier = Modifier.weight(1f)
-                                    ) {
-                                        Text(
-                                            text = device.displayName(),
-                                            style = MaterialTheme.typography.titleSmall,
-                                            fontWeight = FontWeight.SemiBold
-                                        )
+                            val isAssigned =
+                                device.users.any { it.id == selectedUser.id }
 
-                                        Spacer(modifier = Modifier.height(4.dp))
-
-                                        Text(
-                                            text = buildString {
-                                                append(stringResource(deviceTypeToTextRes(device.type)))
-                                                if (roomName.isNotBlank()) {
-                                                    append(" • ")
-                                                    append(roomName)
-                                                }
-                                            },
-                                            style = MaterialTheme.typography.bodyMedium,
-                                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                                        )
-
-                                        if (description.isNotBlank()) {
-                                            Spacer(modifier = Modifier.height(4.dp))
-                                            Text(
-                                                text = description,
-                                                style = MaterialTheme.typography.bodySmall,
-                                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                                            )
-                                        }
-
-                                        Spacer(modifier = Modifier.height(4.dp))
-
-                                        Text(
-                                            text = stringResource(deviceStatusToTextRes(device.online)),
-                                            style = MaterialTheme.typography.bodySmall,
-                                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clickable {
+                                        viewModel.onDeviceToggled(
+                                            selectedUser.id,
+                                            device.id
                                         )
                                     }
+                                    .padding(vertical = 12.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
 
-                                    Checkbox(
-                                        checked = isAssigned,
-                                        onCheckedChange = {
-                                            viewModel.onDeviceToggled(
-                                                selectedUser.id,
-                                                device.id
-                                            )
-                                        }
+                                Column(Modifier.weight(1f)) {
+
+                                    Text(
+                                        text = device.displayName(),
+                                        style = MaterialTheme.typography.titleSmall,
+                                        fontWeight = FontWeight.SemiBold
+                                    )
+
+                                    Spacer(Modifier.height(4.dp))
+
+                                    Text(
+                                        text = stringResource(device.deviceTypeEnum.toTextRes()),
+                                        style = MaterialTheme.typography.bodyMedium
+                                    )
+
+                                    Spacer(Modifier.height(4.dp))
+
+                                    Text(
+                                        text = stringResource(deviceStatusToTextRes(device.online)),
+                                        style = MaterialTheme.typography.bodySmall
                                     )
                                 }
 
-                                if (index != uiState.devices.lastIndex) {
-                                    Divider()
-                                }
+                                Checkbox(
+                                    checked = isAssigned,
+                                    onCheckedChange = {
+                                        viewModel.onDeviceToggled(
+                                            selectedUser.id,
+                                            device.id
+                                        )
+                                    }
+                                )
+                            }
+
+                            if (index != uiState.devices.lastIndex) {
+                                Divider()
                             }
                         }
-                    }
-                }
-            }
-
-            item {
-                Card(
-                    modifier = Modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(20.dp),
-                    colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.cardBackground
-                    )
-                ) {
-                    Column(
-                        modifier = Modifier.padding(vertical = 8.dp)
-                    ) {
-                        ActionRow(
-                            title = stringResource(R.string.save),
-                            icon = {
-                                Icon(
-                                    imageVector = Icons.Rounded.Save,
-                                    contentDescription = null
-                                )
-                            },
-                            onClick = viewModel::saveSelectedUser,
-                            enabled = hasUnsavedChanges
-                        )
                     }
                 }
             }

--- a/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/users/UsersScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/users/UsersScreen.kt
@@ -1,5 +1,6 @@
 package se.hkr.andriod.ui.screens.settings.subscreens.users
 
+import android.R.id.message
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -161,7 +162,7 @@ fun UsersScreen(
                     Column(Modifier.padding(vertical = 8.dp)) {
 
                         ActionRow(
-                            title = "Delete User", // todo translate string
+                            title = stringResource(R.string.delete_user_title),
                             icon = {
                                 Icon(Icons.Rounded.Delete, contentDescription = null)
                             },
@@ -268,8 +269,11 @@ fun UsersScreen(
     // Delete dialog
     if (uiState.showDeleteUserDialog && selectedUser != null) {
         ConfirmDialog(
-            title = "Delete User", // todo translate string
-            message = "Are you sure you want to delete ${selectedUser.username}?", // todo translate string
+            title = stringResource(R.string.delete_user_title),
+            message = stringResource(
+                R.string.delete_user_confirmation_with_name,
+                selectedUser.username
+            ),
             confirmText = stringResource(R.string.delete),
             dismissText = stringResource(R.string.cancel),
             onConfirm = {

--- a/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/users/UsersUiMapper.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/users/UsersUiMapper.kt
@@ -4,6 +4,7 @@ import androidx.annotation.StringRes
 import se.hkr.andriod.R
 import se.hkr.andriod.data.mock.MockDevices
 import se.hkr.andriod.domain.model.device.Device
+import se.hkr.andriod.domain.model.device.DeviceType
 import se.hkr.andriod.domain.model.user.User
 import se.hkr.andriod.domain.model.user.UserRole
 import java.util.UUID
@@ -59,12 +60,21 @@ fun UserRole.toRoleTextRes(): Int {
 }
 
 @StringRes
-fun deviceTypeToTextRes(type: String): Int {
-    return when (type.lowercase()) {
-        "light" -> R.string.device_type_light
-        "lock" -> R.string.device_type_lock
-        "sensor" -> R.string.device_type_sensor
-        else -> R.string.device_type_unknown
+fun DeviceType.toTextRes(): Int {
+    return when (this) {
+        DeviceType.LIGHT -> R.string.device_type_light
+        DeviceType.LOCK -> R.string.device_type_lock
+        DeviceType.SENSOR -> R.string.device_type_sensor
+        DeviceType.GAS -> R.string.device_type_gas
+        DeviceType.HUMIDITY -> R.string.device_type_humidity
+        DeviceType.STEAM -> R.string.device_type_steam
+        DeviceType.BUZZ -> R.string.device_type_buzz
+        DeviceType.FAN -> R.string.device_type_fan
+        DeviceType.SERVO -> R.string.device_type_servo
+        DeviceType.WINDOW -> R.string.device_type_window
+        DeviceType.DOOR -> R.string.device_type_door
+        DeviceType.DISPLAY -> R.string.device_type_display
+        DeviceType.UNKNOWN -> R.string.device_type_unknown
     }
 }
 

--- a/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/users/UsersUiMapper.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/users/UsersUiMapper.kt
@@ -102,12 +102,3 @@ fun Device.displayDescription(): String {
         description.orEmpty()
     }
 }
-
-fun resolveRoomName(roomId: String?): String {
-    if (roomId.isNullOrBlank()) return ""
-
-    return listOf(
-        MockDevices.livingRoom,
-        MockDevices.kitchen
-    ).firstOrNull { it.id == roomId }?.name.orEmpty()
-}

--- a/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/users/UsersViewModel.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/users/UsersViewModel.kt
@@ -69,9 +69,12 @@ class UsersViewModel(
         }
     }
 
-    fun onUserRoleChanged(userId: UUID, role: UserRole) {
+    fun onUserRoleChanged(userName: String, role: UserRole) {
+        val backendRole = role.toBackendType()
         viewModelScope.launch {
-            // TODO: replace with real backend call
+            userStore.updateUserRole(userName, backendRole)
+            delay(100)
+            userStore.fetchUsers()
         }
     }
 

--- a/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/users/UsersViewModel.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/users/UsersViewModel.kt
@@ -90,11 +90,9 @@ class UsersViewModel(
         }
     }
 
-    fun deleteSelectedUser() {
-        val userId = _uiState.value.selectedUserId ?: return
-
+    fun deleteSelectedUser(userName: String) {
         viewModelScope.launch {
-            // TODO: replace with real backend call
+            userStore.deleteUser(userName)
             dismissDialogs()
         }
     }

--- a/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/users/UsersViewModel.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/users/UsersViewModel.kt
@@ -9,12 +9,14 @@ import se.hkr.andriod.data.network.DeviceStore
 import se.hkr.andriod.data.network.UserStore
 import se.hkr.andriod.domain.model.device.Device
 import se.hkr.andriod.domain.model.user.User
+import se.hkr.andriod.domain.model.user.UserRole
 import java.util.UUID
 
 data class UsersUiState(
     val users: List<User> = emptyList(),
     val devices: List<Device> = emptyList(),
-    val selectedUserId: UUID? = null
+    val selectedUserId: UUID? = null,
+    val showDeleteUserDialog: Boolean = false
 )
 
 class UsersViewModel(
@@ -42,7 +44,9 @@ class UsersViewModel(
                 UsersUiState(
                     users = users,
                     devices = devices,
-                    selectedUserId = selectedUserId ?: users.firstOrNull()?.id
+                    selectedUserId = selectedUserId ?: users.firstOrNull()?.id,
+                    // preserve dialog state across refresh
+                    showDeleteUserDialog = _uiState.value.showDeleteUserDialog
                 )
             }.collect { state ->
                 _uiState.value = state
@@ -62,6 +66,33 @@ class UsersViewModel(
             deviceStore.fetchAllDeviceInfo()
             delay(100)
             deviceStore.fetchAllDeviceInfo()
+        }
+    }
+
+    fun onUserRoleChanged(userId: UUID, role: UserRole) {
+        viewModelScope.launch {
+            // TODO: replace with real backend call
+        }
+    }
+
+    fun showDeleteUserDialog() {
+        _uiState.update {
+            it.copy(showDeleteUserDialog = true)
+        }
+    }
+
+    fun dismissDialogs() {
+        _uiState.update {
+            it.copy(showDeleteUserDialog = false)
+        }
+    }
+
+    fun deleteSelectedUser() {
+        val userId = _uiState.value.selectedUserId ?: return
+
+        viewModelScope.launch {
+            // TODO: replace with real backend call
+            dismissDialogs()
         }
     }
 }

--- a/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/users/UsersViewModel.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/users/UsersViewModel.kt
@@ -7,6 +7,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import se.hkr.andriod.data.mock.MockDevices
 import se.hkr.andriod.data.mock.MockUsers
+import se.hkr.andriod.data.network.DeviceStore
+import se.hkr.andriod.data.network.UserStore
 import se.hkr.andriod.domain.model.device.Device
 import se.hkr.andriod.domain.model.user.User
 import java.util.UUID
@@ -19,7 +21,10 @@ data class UsersUiState(
     val editedAssignments: Map<UUID, Set<String>> = emptyMap()
 )
 
-class UsersViewModel : ViewModel() {
+class UsersViewModel(
+    private val userStore: UserStore,
+    private val deviceStore: DeviceStore
+) : ViewModel() {
 
     private val initialUsers = MockUsers.allUsers
     private val initialDevices = MockDevices.allDevices

--- a/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/users/UsersViewModel.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/users/UsersViewModel.kt
@@ -1,12 +1,9 @@
 package se.hkr.andriod.ui.screens.settings.subscreens.users
 
 import androidx.lifecycle.ViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
-import se.hkr.andriod.data.mock.MockDevices
-import se.hkr.andriod.data.mock.MockUsers
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
 import se.hkr.andriod.data.network.DeviceStore
 import se.hkr.andriod.data.network.UserStore
 import se.hkr.andriod.domain.model.device.Device
@@ -16,9 +13,7 @@ import java.util.UUID
 data class UsersUiState(
     val users: List<User> = emptyList(),
     val devices: List<Device> = emptyList(),
-    val selectedUserId: UUID? = null,
-    val savedAssignments: Map<UUID, Set<String>> = emptyMap(),
-    val editedAssignments: Map<UUID, Set<String>> = emptyMap()
+    val selectedUserId: UUID? = null
 )
 
 class UsersViewModel(
@@ -26,75 +21,41 @@ class UsersViewModel(
     private val deviceStore: DeviceStore
 ) : ViewModel() {
 
-    private val initialUsers = MockUsers.allUsers
-    private val initialDevices = MockDevices.allDevices
-
-    private val initialAssignments: Map<UUID, Set<String>> =
-        MockUserDeviceAssignments.assignments.mapNotNull { (userIdString, deviceIds) ->
-            userIdString.toUUIDOrNull()?.let { uuid ->
-                uuid to deviceIds
-            }
-        }.toMap()
-
-    private val _uiState = MutableStateFlow(
-        UsersUiState(
-            users = initialUsers,
-            devices = initialDevices,
-            selectedUserId = initialUsers.firstOrNull()?.id,
-            savedAssignments = initialAssignments
-        )
-    )
+    private val _uiState = MutableStateFlow(UsersUiState())
     val uiState: StateFlow<UsersUiState> = _uiState.asStateFlow()
 
-    fun onUserSelected(userId: UUID) {
-        _uiState.update { state ->
-            state.copy(selectedUserId = userId)
+    init {
+        userStore.fetchUsers()
+        deviceStore.fetchAllDeviceInfo()
+        observeStores()
+    }
+
+    private fun observeStores() {
+        viewModelScope.launch {
+            combine(
+                userStore.users,
+                deviceStore.allDevices,
+                _uiState.map { it.selectedUserId }
+            ) { users, devices, selectedUserId ->
+
+                UsersUiState(
+                    users = users,
+                    devices = devices,
+                    selectedUserId = selectedUserId ?: users.firstOrNull()?.id
+                )
+            }.collect { state ->
+                _uiState.value = state
+            }
         }
+    }
+
+    fun onUserSelected(userId: UUID) {
+        _uiState.update { it.copy(selectedUserId = userId) }
     }
 
     fun onDeviceToggled(userId: UUID, deviceId: String) {
-        _uiState.update { state ->
-            val currentAssignments = state.editedAssignments[userId]
-                ?: state.savedAssignments[userId]
-                ?: emptySet()
-
-            val updatedAssignments =
-                if (deviceId in currentAssignments) {
-                    currentAssignments - deviceId
-                } else {
-                    currentAssignments + deviceId
-                }
-
-            state.copy(
-                editedAssignments = state.editedAssignments + (userId to updatedAssignments)
-            )
-        }
-    }
-
-    fun saveSelectedUser() {
-        _uiState.update { state ->
-            val selectedUserId = state.selectedUserId ?: return@update state
-            val updatedAssignments = state.editedAssignments[selectedUserId] ?: return@update state
-
-            state.copy(
-                savedAssignments = state.savedAssignments + (selectedUserId to updatedAssignments),
-                editedAssignments = state.editedAssignments - selectedUserId
-            )
-        }
-    }
-
-    fun hasUnsavedChanges(userId: UUID): Boolean {
-        val state = _uiState.value
-        val saved = state.savedAssignments[userId] ?: emptySet()
-        val edited = state.editedAssignments[userId] ?: saved
-        return saved != edited
-    }
-
-    private fun String.toUUIDOrNull(): UUID? {
-        return try {
-            UUID.fromString(this)
-        } catch (_: IllegalArgumentException) {
-            null
+        viewModelScope.launch {
+            // todo: backend call
         }
     }
 }

--- a/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/users/UsersViewModel.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/users/UsersViewModel.kt
@@ -2,6 +2,7 @@ package se.hkr.andriod.ui.screens.settings.subscreens.users
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import se.hkr.andriod.data.network.DeviceStore
@@ -55,7 +56,12 @@ class UsersViewModel(
 
     fun onDeviceToggled(userId: UUID, deviceId: String) {
         viewModelScope.launch {
-            // todo: backend call
+            userStore.addUserToDevice(userId, deviceId)
+
+            // Not a good solution but it works for now
+            deviceStore.fetchAllDeviceInfo()
+            delay(100)
+            deviceStore.fetchAllDeviceInfo()
         }
     }
 }

--- a/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/users/UsersViewModelFactory.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/users/UsersViewModelFactory.kt
@@ -1,0 +1,20 @@
+package se.hkr.andriod.ui.screens.settings.subscreens.users
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import se.hkr.andriod.data.network.DeviceStore
+import se.hkr.andriod.data.network.UserStore
+
+class UsersViewModelFactory(
+    private val userStore: UserStore,
+    private val deviceStore: DeviceStore
+) : ViewModelProvider.Factory {
+
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(UsersViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return UsersViewModel(userStore, deviceStore) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -165,6 +165,7 @@
     <string name="edit_username">Felhasználónév módosítása</string>
 
     <!-- Settings - Users & Permissions -->
+    <string name="user">Felhasználó</string>
     <string name="settings_users_devices">Felhasználók és eszközök</string>
     <string name="assigned_devices">Hozzárendelt eszközök</string>
     <string name="assigned_devices_count">%1$d eszköz hozzárendelve</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -171,6 +171,8 @@
     <string name="assigned_devices_count">%1$d eszköz hozzárendelve</string>
     <string name="no_devices_available">Nincsenek elérhető eszközök</string>
     <string name="device_type_unknown">Ismeretlen eszköz</string>
+    <string name="delete_user_title">Felhasználó törlése</string>
+    <string name="delete_user_confirmation_with_name">Biztosan törölni szeretnéd a(z) "%1$s" felhasználót?</string>
 
     <string name="admin">Admin</string>
     <string name="base_user">Alap felhasználó</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -168,6 +168,7 @@
     <string name="edit_username">Ändra användarnamn</string>
 
     <!-- Settings - Users & Permissions -->
+    <string name="user">Användare</string>
     <string name="settings_users_devices">Användare och enheter</string>
     <string name="assigned_devices">Tilldelade enheter</string>
     <string name="assigned_devices_count">%1$d enheter tilldelade</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -174,6 +174,8 @@
     <string name="assigned_devices_count">%1$d enheter tilldelade</string>
     <string name="no_devices_available">Inga enheter tillgängliga</string>
     <string name="device_type_unknown">Okänd enhet</string>
+    <string name="delete_user_title">Ta bort användare</string>
+    <string name="delete_user_confirmation_with_name">Är du säker på att du vill ta bort "%1$s"?</string>
 
     <string name="admin">Admin</string>
     <string name="base_user">Standardanvändare</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -170,6 +170,8 @@
     <string name="assigned_devices_count">%1$d devices assigned</string>
     <string name="no_devices_available">No devices available</string>
     <string name="device_type_unknown">Unknown device</string>
+    <string name="delete_user_title">Delete User</string>
+    <string name="delete_user_confirmation_with_name">Are you sure you want to delete "%1$s"?</string>
 
     <string name="admin">Admin</string>
     <string name="base_user">Base user</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -164,6 +164,7 @@
     <string name="edit_username">Edit username</string>
 
     <!-- Settings - Users & Permissions -->
+    <string name="user">User</string>
     <string name="settings_users_devices">Users &amp; Devices</string>
     <string name="assigned_devices">Assigned devices</string>
     <string name="assigned_devices_count">%1$d devices assigned</string>


### PR DESCRIPTION
Added UsersViewModelFactory to pass userStore and deviceStore into UsersViewModel
Refactored userStore to use correct UUID and domain.model.user types
Updated UsersUiMapper to support all currently supported device types
Removed save button from UserScreen and updated ViewModel to load users and devices from stores
Added device assignment UI for users using checkboxes
Updated UI text from “Base user” to “Users”
Enabled assigning devices to users
Restored room name display and removed outdated user UI mapper logic
Added delete user button with confirmation popup
Added role display and role selection UI
Added translations for delete user flow
Added toBackendType function for mapping roles to backend-compatible values
Updated updateUserRole to use username instead of userId
Connected role update function from UserStore to UserScreen
Updated deleteUser to use username instead of userId
Connected deleteUser function in UserStore to UserScreen for user deletion