### PR TITLE
114 update currentuser to use real role instead of mocked role

### DIFF
--- a/app/src/main/java/se/hkr/andriod/data/network/AuthSession.kt
+++ b/app/src/main/java/se/hkr/andriod/data/network/AuthSession.kt
@@ -2,18 +2,30 @@ package se.hkr.andriod.data.network
 
 import android.content.Context
 import androidx.core.content.edit
+import org.json.JSONObject
+import android.util.Base64
 
 object AuthSession {
     private var accessToken: String? = null
     private var username: String? = null
+    private var userId: String? = null
+    private var role: String? = null
 
     fun saveSession(context: Context, token: String, username: String) {
         accessToken = token
         this.username = username
+
+        // Extract userId and role from JWT
+        val parsed = parseToken(token)
+        userId = parsed?.first
+        role = parsed?.second
+
         val prefs = context.getSharedPreferences("auth", Context.MODE_PRIVATE)
         prefs.edit {
             putString("access_token", token)
             putString("username", username)
+            putString("user_id", userId)
+            putString("role", role)
         }
     }
 
@@ -21,17 +33,31 @@ object AuthSession {
         val prefs = context.getSharedPreferences("auth", Context.MODE_PRIVATE)
         accessToken = prefs.getString("access_token", null)
         username = prefs.getString("username", null)
+        userId = prefs.getString("user_id", null)
+        role = prefs.getString("role", null)
     }
 
     fun saveToken(context: Context, token: String) {
         accessToken = token
+
+        // Re-parse token on refresh
+        val parsed = parseToken(token)
+        userId = parsed?.first
+        role = parsed?.second
+
         val prefs = context.getSharedPreferences("auth", Context.MODE_PRIVATE)
-        prefs.edit { putString("access_token", token) }
+        prefs.edit {
+            putString("access_token", token)
+            putString("user_id", userId)
+            putString("role", role)
+        }
     }
 
     fun loadToken(context: Context) {
         val prefs = context.getSharedPreferences("auth", Context.MODE_PRIVATE)
         accessToken = prefs.getString("access_token", null)
+        userId = prefs.getString("user_id", null)
+        role = prefs.getString("role", null)
     }
 
     fun getToken(): String? {
@@ -42,9 +68,19 @@ object AuthSession {
         return username
     }
 
+    fun getUserId(): String? {
+        return userId
+    }
+
+    fun getRole(): String? {
+        return role
+    }
+
     fun clear(context: Context) {
         accessToken = null
         username = null
+        userId = null
+        role = null
 
         val prefs = context.getSharedPreferences("auth", Context.MODE_PRIVATE)
         prefs.edit { clear() }
@@ -52,5 +88,26 @@ object AuthSession {
 
     fun isLoggedIn(): Boolean {
         return accessToken != null
+    }
+
+    // JWT parser
+    private fun parseToken(token: String): Pair<String, String>? {
+        return try {
+            val parts = token.split(".")
+            val payload = parts[1]
+
+            val decodedBytes = Base64.decode(payload, Base64.URL_SAFE)
+            val decodedString = String(decodedBytes)
+
+            val json = JSONObject(decodedString)
+
+            val userId = json.getString("sub")
+            val role = json.getString("role")
+
+            Pair(userId, role)
+
+        } catch (e: Exception) {
+            null
+        }
     }
 }

--- a/app/src/main/java/se/hkr/andriod/data/network/AuthSession.kt
+++ b/app/src/main/java/se/hkr/andriod/data/network/AuthSession.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import androidx.core.content.edit
 import org.json.JSONObject
 import android.util.Base64
+import se.hkr.andriod.domain.model.user.User
+import se.hkr.andriod.domain.model.user.UserRole
 import java.util.UUID
 
 object AuthSession {
@@ -83,6 +85,16 @@ object AuthSession {
 
     fun getRole(): String? {
         return role
+    }
+
+    fun getUser(): User {
+        val role = UserRole.fromBackendType(role ?: "user")
+
+        return User(
+            id = userId ?: error("No userId in session"),
+            username = username ?: "",
+            role = role
+        )
     }
 
     fun clear(context: Context) {

--- a/app/src/main/java/se/hkr/andriod/data/network/AuthSession.kt
+++ b/app/src/main/java/se/hkr/andriod/data/network/AuthSession.kt
@@ -4,11 +4,12 @@ import android.content.Context
 import androidx.core.content.edit
 import org.json.JSONObject
 import android.util.Base64
+import java.util.UUID
 
 object AuthSession {
     private var accessToken: String? = null
     private var username: String? = null
-    private var userId: String? = null
+    private var userId: UUID? = null
     private var role: String? = null
 
     fun saveSession(context: Context, token: String, username: String) {
@@ -24,7 +25,7 @@ object AuthSession {
         prefs.edit {
             putString("access_token", token)
             putString("username", username)
-            putString("user_id", userId)
+            putString("user_id", userId?.toString())
             putString("role", role)
         }
     }
@@ -33,7 +34,11 @@ object AuthSession {
         val prefs = context.getSharedPreferences("auth", Context.MODE_PRIVATE)
         accessToken = prefs.getString("access_token", null)
         username = prefs.getString("username", null)
-        userId = prefs.getString("user_id", null)
+
+        userId = prefs.getString("user_id", null)?.let {
+            try { UUID.fromString(it) } catch (_: Exception) { null }
+        }
+
         role = prefs.getString("role", null)
     }
 
@@ -48,7 +53,7 @@ object AuthSession {
         val prefs = context.getSharedPreferences("auth", Context.MODE_PRIVATE)
         prefs.edit {
             putString("access_token", token)
-            putString("user_id", userId)
+            putString("user_id", userId?.toString())
             putString("role", role)
         }
     }
@@ -56,7 +61,11 @@ object AuthSession {
     fun loadToken(context: Context) {
         val prefs = context.getSharedPreferences("auth", Context.MODE_PRIVATE)
         accessToken = prefs.getString("access_token", null)
-        userId = prefs.getString("user_id", null)
+
+        userId = prefs.getString("user_id", null)?.let {
+            try { UUID.fromString(it) } catch (_: Exception) { null }
+        }
+
         role = prefs.getString("role", null)
     }
 
@@ -68,7 +77,7 @@ object AuthSession {
         return username
     }
 
-    fun getUserId(): String? {
+    fun getUserId(): UUID? {
         return userId
     }
 
@@ -90,8 +99,7 @@ object AuthSession {
         return accessToken != null
     }
 
-    // JWT parser
-    private fun parseToken(token: String): Pair<String, String>? {
+    private fun parseToken(token: String): Pair<UUID, String>? {
         return try {
             val parts = token.split(".")
             val payload = parts[1]
@@ -101,7 +109,7 @@ object AuthSession {
 
             val json = JSONObject(decodedString)
 
-            val userId = json.getString("sub")
+            val userId = UUID.fromString(json.getString("sub"))
             val role = json.getString("role")
 
             Pair(userId, role)

--- a/app/src/main/java/se/hkr/andriod/ui/components/AppHomeTopBar.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/components/AppHomeTopBar.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import se.hkr.andriod.R
-import se.hkr.andriod.data.mock.currentUser
+import se.hkr.andriod.data.network.AuthSession.getUser
 import se.hkr.andriod.ui.theme.AndriodTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -28,6 +28,8 @@ fun AppHomeTopBar(
     offlineCount: Int? = null,
     onAddClick: () -> Unit
 ) {
+    val currentUser = getUser()
+
     TopAppBar(
         windowInsets = WindowInsets.statusBars,
         title = {

--- a/app/src/main/java/se/hkr/andriod/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/settings/SettingsScreen.kt
@@ -14,8 +14,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import se.hkr.andriod.R
-import se.hkr.andriod.data.mock.currentUser
 import se.hkr.andriod.data.network.*
+import se.hkr.andriod.data.network.AuthSession.getUser
 import se.hkr.andriod.navigation.Routes
 import se.hkr.andriod.ui.components.AppButton
 import se.hkr.andriod.ui.screens.settings.components.SettingsItem
@@ -33,6 +33,8 @@ fun SettingsScreen(
     var showThemeDialog by remember { mutableStateOf(false) }
 
     val devices by connectionManager.deviceStore.devices.collectAsState()
+
+    val currentUser = getUser()
 
     LaunchedEffect(devices) {
         Log.d("DEVICE_STORE", "Current devices: $devices")


### PR DESCRIPTION
The app now stores user ID and role from the JWT.
Role based permissions are now reflected using real current role isntead of mocked role.