### PR TITLE
116 device screen fetch all devices instead of initial devices

### DIFF
--- a/app/src/main/java/se/hkr/andriod/data/network/DeviceStore.kt
+++ b/app/src/main/java/se/hkr/andriod/data/network/DeviceStore.kt
@@ -34,6 +34,7 @@ class DeviceStore(private val webSocketManager: WebSocketManager) {
                 "update value" -> handleDeviceUpdate(payload)
                 "added new device" -> handleAddedNewDevice(payload)
                 "update device onlinestate" -> handleDeviceOnlineState(payload)
+                "update device description" -> handleDeviceUpdateDescription(payload)
                 "device info" -> handleAllDeviceInfo(payload)
                 else -> Log.d("DEVICESTORE", "Unhandled message type: $type")
             }
@@ -115,6 +116,31 @@ class DeviceStore(private val webSocketManager: WebSocketManager) {
         }
 
         Log.d("DEVICESTORE", "Device online state updated: $deviceId : $isOnline")
+    }
+
+    private fun handleDeviceUpdateDescription(payload: JSONObject) {
+        val deviceId = payload.optString("deviceID")
+        val content = payload.optJSONObject("content") ?: return
+
+        val newName = content.optString("name", "")
+        val newDescription = content.optString("description", "")
+
+        if (deviceId.isEmpty()) return
+
+        scope.launch {
+            val updateDevice: (Device) -> Device = { device ->
+                if (device.id == deviceId) {
+                    device.copy(
+                        name = newName,
+                        description = newDescription
+                    )
+                } else device
+            }
+
+            _devices.update { list -> list.map(updateDevice) }
+            _allDevices.update { list -> list.map(updateDevice) }
+        }
+        Log.d("DEVICESTORE", "Device description updated: $deviceId -> $newName / $newDescription")
     }
 
     private fun handleAllDeviceInfo(payload: JSONObject) {

--- a/app/src/main/java/se/hkr/andriod/data/network/MessageRouter.kt
+++ b/app/src/main/java/se/hkr/andriod/data/network/MessageRouter.kt
@@ -24,6 +24,7 @@ class MessageRouter(
                 "update value",
                 "added new device",
                 "update device onlinestate",
+                "update device description",
                 "device info" -> deviceStore.handleMessage(json)
 
                 // User messages

--- a/app/src/main/java/se/hkr/andriod/ui/screens/main/MainScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/main/MainScreen.kt
@@ -200,7 +200,9 @@ fun MainScreen(
 
                 composable(Routes.DEVICES) {
                     val viewModel: DevicesViewModel = viewModel(
-                        factory = DevicesViewModelFactory(connectionManager.deviceStore)
+                        factory = DevicesViewModelFactory(
+                            connectionManager.deviceStore, connectionManager.roomStore
+                        )
                     )
 
                     DevicesScreen(

--- a/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/devices/DevicesScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/devices/DevicesScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -46,7 +45,6 @@ import se.hkr.andriod.ui.screens.settings.components.ConfirmDialog
 import se.hkr.andriod.ui.screens.settings.components.DialogOption
 import se.hkr.andriod.ui.screens.settings.components.InfoRow
 import se.hkr.andriod.ui.screens.settings.components.InputDialog
-import se.hkr.andriod.ui.screens.settings.components.SettingsItem
 import se.hkr.andriod.ui.screens.settings.components.SingleChoiceDialog
 import se.hkr.andriod.ui.theme.cardBackground
 import se.hkr.andriod.ui.theme.lightBlue
@@ -185,7 +183,11 @@ fun DevicesScreen(
                         horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
                         InfoRow(text = deviceInfo.type)
-                        InfoRow(text = deviceInfo.room)
+
+                        if (deviceInfo.room.isNotBlank() && deviceInfo.room != "null") {
+                            InfoRow(text = deviceInfo.room)
+                        }
+
                         InfoRow(text = deviceInfo.status)
                     }
 

--- a/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/devices/DevicesViewModel.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/devices/DevicesViewModel.kt
@@ -24,11 +24,6 @@ data class DevicesUiState(
     val selectedDevice: Device?
         get() = devices.firstOrNull { it.id == selectedDeviceId }
 
-    fun getRoomName(roomId: String?): String? {
-        if (roomId.isNullOrBlank()) return null
-        return rooms.firstOrNull { it.id == roomId }?.name
-    }
-
     val availableRooms: List<Room>
         get() = rooms.sortedBy { it.name }
 }

--- a/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/devices/DevicesViewModel.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/devices/DevicesViewModel.kt
@@ -6,30 +6,23 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import se.hkr.andriod.data.mock.MockDevices
 import se.hkr.andriod.data.network.DeviceStore
+import se.hkr.andriod.data.network.RoomStore
 import se.hkr.andriod.domain.model.device.Device
 import se.hkr.andriod.domain.model.device.Room
 
 data class DevicesUiState(
-    val devices: List<Device> = MockDevices.allDevices,
-    val rooms: List<Room> = listOf(
-        MockDevices.livingRoom,
-        MockDevices.kitchen
-    ),
-    val selectedDeviceId: String =
-        MockDevices.allDevices.firstOrNull()?.id.orEmpty(),
-
+    val devices: List<Device> = emptyList(),
+    val rooms: List<Room> = emptyList(),
+    val selectedDeviceId: String = "",
     val showRenameDialog: Boolean = false,
     val showDeleteDialog: Boolean = false,
     val showChangeRoomDialog: Boolean = false,
-
     val inputText: String = "",
-    val selectedRoomIdForDialog: String =
-        MockDevices.allDevices.firstOrNull()?.room.orEmpty()
+    val selectedRoomIdForDialog: String = ""
 ) {
     val selectedDevice: Device?
-        get() = devices.firstOrNull() { it.id == selectedDeviceId }
+        get() = devices.firstOrNull { it.id == selectedDeviceId }
 
     fun getRoomName(roomId: String?): String? {
         if (roomId.isNullOrBlank()) return null
@@ -38,28 +31,47 @@ data class DevicesUiState(
 
     val availableRooms: List<Room>
         get() = rooms.sortedBy { it.name }
-
 }
 
 class DevicesViewModel(
-    private val deviceStore: DeviceStore
+    private val deviceStore: DeviceStore,
+    private val roomStore: RoomStore
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(DevicesUiState())
     val uiState: StateFlow<DevicesUiState> = _uiState
 
     init {
+        roomStore.getRooms()
+        deviceStore.fetchAllDeviceInfo()
+        observeStores()
+    }
+
+    private fun observeStores() {
+        // Observe devices
         viewModelScope.launch {
-            deviceStore.devices.collect { devices ->
+            deviceStore.allDevices.collect { devices ->
                 _uiState.update { state ->
                     val selectedId = state.selectedDeviceId
                         .takeIf { id -> devices.any { it.id == id } }
                         ?: devices.firstOrNull()?.id.orEmpty()
 
+                    val selectedDevice = devices.firstOrNull { it.id == selectedId }
+
                     state.copy(
                         devices = devices,
-                        selectedDeviceId = selectedId
+                        selectedDeviceId = selectedId,
+                        selectedRoomIdForDialog = selectedDevice?.room.orEmpty()
                     )
+                }
+            }
+        }
+
+        // Observe rooms
+        viewModelScope.launch {
+            roomStore.rooms.collect { rooms ->
+                _uiState.update { state ->
+                    state.copy(rooms = rooms)
                 }
             }
         }
@@ -67,19 +79,18 @@ class DevicesViewModel(
 
     fun onDeviceSelected(deviceId: String) {
         _uiState.update { state ->
-            val updatedState = state.copy(selectedDeviceId = deviceId)
-
-            val selectedDevice = updatedState.selectedDevice
+            val selectedDevice = state.devices.firstOrNull { it.id == deviceId }
                 ?: return@update state
 
-            updatedState.copy(
+            state.copy(
+                selectedDeviceId = deviceId,
                 selectedRoomIdForDialog = selectedDevice.room.orEmpty()
             )
         }
     }
 
     fun onInputChanged(value: String) {
-        _uiState.value = _uiState.value.copy(inputText = value)
+        _uiState.update { it.copy(inputText = value) }
     }
 
     fun onRoomSelectedForDialog(roomId: String) {
@@ -111,8 +122,10 @@ class DevicesViewModel(
     }
 
     fun renameSelectedDevice() {
-        val selectedDevice = _uiState.value.selectedDevice ?: return
-        val newName = _uiState.value.inputText.trim()
+        val state = _uiState.value
+        val selectedDevice = state.selectedDevice ?: return
+        val newName = state.inputText.trim()
+
         if (newName.isEmpty() || newName == selectedDevice.displayName) return
 
         // Use current description to avoid overwriting it

--- a/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/devices/DevicesViewModelFactory.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/settings/subscreens/devices/DevicesViewModelFactory.kt
@@ -3,15 +3,17 @@ package se.hkr.andriod.ui.screens.settings.subscreens.devices
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import se.hkr.andriod.data.network.DeviceStore
+import se.hkr.andriod.data.network.RoomStore
 
 class DevicesViewModelFactory(
-    private val deviceStore: DeviceStore
+    private val deviceStore: DeviceStore,
+    private val roomStore: RoomStore
 ) : ViewModelProvider.Factory {
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(DevicesViewModel::class.java)) {
             @Suppress("UNCHECKED_CAST")
-            return DevicesViewModel(deviceStore) as T
+            return DevicesViewModel(deviceStore, roomStore) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class")
     }


### PR DESCRIPTION
DevicesScreen now fetches allDevices and uses it to display devices.
"update device description" incoming message after device updates are now handeled to ensure that _allDevices is up to date.
Devices with no room no longer display "null" in the room pill.