### PR TITLE
109 login message incorrect username or password

### DIFF
--- a/app/src/main/java/se/hkr/andriod/data/network/AuthService.kt
+++ b/app/src/main/java/se/hkr/andriod/data/network/AuthService.kt
@@ -58,7 +58,7 @@ class AuthService(private val context: Context) {
         postRequest(url, json) { success, response ->
 
             if (!success || response == null) {
-                onResult(false, "Login failed")
+                onResult(false, "Incorrect username or password")
                 return@postRequest
             }
 

--- a/app/src/main/java/se/hkr/andriod/ui/screens/login/LoginScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/login/LoginScreen.kt
@@ -116,6 +116,23 @@ fun LoginScreen(
                         errorText = uiState.passwordError?.let { stringResource(it) }
                     )
 
+                    uiState.loginError?.let { error ->
+                        Card(
+                            colors = CardDefaults.cardColors(
+                                containerColor = MaterialTheme.colorScheme.errorContainer
+                            ),
+                            modifier = Modifier.fillMaxWidth(),
+                            shape = MaterialTheme.shapes.small
+                        ) {
+                            Text(
+                                text = error,
+                                color = MaterialTheme.colorScheme.onErrorContainer,
+                                modifier = Modifier.padding(10.dp),
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                        }
+                    }
+
                     AppButton(
                         text = stringResource(R.string.sign_in_button),
                         loadingText = stringResource(R.string.signing_in),

--- a/app/src/main/java/se/hkr/andriod/ui/screens/signup/SignUpScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/signup/SignUpScreen.kt
@@ -129,6 +129,23 @@ fun SignUpScreen(
                         helperText = stringResource(R.string.password_helper_text)
                     )
 
+                    uiState.registerError?.let { error ->
+                        Card(
+                            colors = CardDefaults.cardColors(
+                                containerColor = MaterialTheme.colorScheme.errorContainer
+                            ),
+                            modifier = Modifier.fillMaxWidth(),
+                            shape = MaterialTheme.shapes.small
+                        ) {
+                            Text(
+                                text = error,
+                                color = MaterialTheme.colorScheme.onErrorContainer,
+                                modifier = Modifier.padding(10.dp),
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                        }
+                    }
+
                     AppButton(
                         text = stringResource(R.string.sign_up_button),
                         loadingText = stringResource(R.string.signing_up),


### PR DESCRIPTION
Added error displaying of login and register errors for the login and register pages.
Updated the login failed message to instead say wrong username or password.