### PR TITLE
137 rooms overview screen

### DIFF
--- a/app/src/main/java/se/hkr/andriod/navigation/BottomNavItem.kt
+++ b/app/src/main/java/se/hkr/andriod/navigation/BottomNavItem.kt
@@ -20,8 +20,8 @@ sealed class BottomNavItem(
     )
 
     object Management : BottomNavItem(
-        route = Routes.DEVICE_MANAGEMENT,
-        labelRes = R.string.nav_manage_devices,
+        route = Routes.ROOMS_OVERVIEW,
+        labelRes = R.string.rooms,
         icon = Icons.Rounded.Widgets
     )
 

--- a/app/src/main/java/se/hkr/andriod/navigation/Routes.kt
+++ b/app/src/main/java/se/hkr/andriod/navigation/Routes.kt
@@ -20,9 +20,12 @@ object Routes {
     const val ACCOUNT = "account"
 
     const val DEVICE_CARD = "device_card/{type}/{id}"
-
     fun deviceCard(device: Device): String {
         return "device_card/${device.deviceTypeEnum.name}/${device.id}"
     }
 
+    const val ROOM_DETAILS = "room_details/{roomName}"
+    fun roomDetails(roomName: String): String {
+        return "room_details/$roomName"
+    }
 }

--- a/app/src/main/java/se/hkr/andriod/navigation/Routes.kt
+++ b/app/src/main/java/se/hkr/andriod/navigation/Routes.kt
@@ -9,7 +9,7 @@ object Routes {
     const val MAIN = "main"
 
     const val DEVICE_OVERVIEW = "device_overview"
-    const val DEVICE_MANAGEMENT = "device_management"
+    const val ROOMS_OVERVIEW = "rooms_overview"
     const val SETTINGS = "settings"
 
     const val USERS = "users"

--- a/app/src/main/java/se/hkr/andriod/ui/components/RoomCardItem.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/components/RoomCardItem.kt
@@ -6,9 +6,11 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import se.hkr.andriod.ui.theme.cardBackground
+import se.hkr.andriod.R
 
 @Composable
 fun RoomCardItem(
@@ -54,7 +56,11 @@ fun RoomCardItem(
                 Spacer(modifier = Modifier.height(4.dp))
 
                 Text(
-                    text = "$deviceCount devices",
+                    text = pluralStringResource(
+                        id = R.plurals.device_count,
+                        count = deviceCount,
+                        deviceCount
+                    ),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )

--- a/app/src/main/java/se/hkr/andriod/ui/components/RoomCardItem.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/components/RoomCardItem.kt
@@ -1,5 +1,6 @@
 package se.hkr.andriod.ui.components
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
@@ -17,12 +18,18 @@ fun RoomCardItem(
     enabled: Boolean,
     checked: Boolean,
     onSwitchToggle: (Boolean) -> Unit,
+    onClick: (() -> Unit)? = null,
     elevation: Dp = 0.dp
 ) {
     Card(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp),
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .then(
+                if (onClick != null)
+                    Modifier.clickable { onClick() }
+                else Modifier
+            ),
         shape = MaterialTheme.shapes.medium,
         elevation = CardDefaults.cardElevation(defaultElevation = elevation),
         colors = CardDefaults.cardColors(

--- a/app/src/main/java/se/hkr/andriod/ui/components/RoomCardItem.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/components/RoomCardItem.kt
@@ -1,0 +1,62 @@
+package se.hkr.andriod.ui.components
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import se.hkr.andriod.ui.theme.cardBackground
+
+@Composable
+fun RoomCardItem(
+    modifier: Modifier = Modifier,
+    roomName: String,
+    deviceCount: Int,
+    enabled: Boolean,
+    checked: Boolean,
+    onSwitchToggle: (Boolean) -> Unit,
+    elevation: Dp = 0.dp
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        shape = MaterialTheme.shapes.medium,
+        elevation = CardDefaults.cardElevation(defaultElevation = elevation),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.cardBackground
+        )
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(
+                modifier = Modifier.weight(1f)
+            ) {
+
+                Text(
+                    text = roomName,
+                    style = MaterialTheme.typography.titleMedium
+                )
+
+                Spacer(modifier = Modifier.height(4.dp))
+
+                Text(
+                    text = "$deviceCount devices",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Switch(
+                checked = checked,
+                onCheckedChange = onSwitchToggle,
+                enabled = enabled
+            )
+        }
+    }
+}

--- a/app/src/main/java/se/hkr/andriod/ui/screens/main/MainScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/main/MainScreen.kt
@@ -184,6 +184,12 @@ fun MainScreen(
                 val roomName =
                     backStackEntry.arguments?.getString("roomName")
                         ?: error("Missing room name")
+
+                RoomDetailsScreen(
+                    navController = navController,
+                    connectionManager = connectionManager,
+                    roomName = roomName
+                )
             }
 
             navigation(

--- a/app/src/main/java/se/hkr/andriod/ui/screens/main/MainScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/main/MainScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import se.hkr.andriod.navigation.Routes
-import se.hkr.andriod.ui.screens.devicemanagement.DeviceManagementScreen
 import se.hkr.andriod.ui.screens.deviceoverview.DeviceOverviewScreen
 import se.hkr.andriod.ui.screens.settings.SettingsScreen
 import androidx.compose.material3.*
@@ -31,6 +30,7 @@ import se.hkr.andriod.data.network.NetworkModule
 import se.hkr.andriod.data.network.PersistentCookieJar
 import se.hkr.andriod.navigation.BottomNavItem
 import se.hkr.andriod.ui.screens.devicecard.DeviceHostScreen
+import se.hkr.andriod.ui.screens.roomsoverviewscreen.RoomsOverviewScreen
 import se.hkr.andriod.ui.screens.settings.subscreens.accountinfo.AccountInfoScreen
 import se.hkr.andriod.ui.screens.settings.subscreens.language.LanguageScreen
 import se.hkr.andriod.ui.screens.settings.subscreens.rooms.RoomsScreen
@@ -149,8 +149,11 @@ fun MainScreen(
                 )
             }
 
-            composable(Routes.DEVICE_MANAGEMENT) {
-                DeviceManagementScreen()
+            composable(Routes.ROOMS_OVERVIEW) {
+                RoomsOverviewScreen(
+                    navController = navController,
+                    connectionManager = connectionManager
+                )
             }
 
             composable(

--- a/app/src/main/java/se/hkr/andriod/ui/screens/main/MainScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/main/MainScreen.kt
@@ -30,6 +30,7 @@ import se.hkr.andriod.data.network.NetworkModule
 import se.hkr.andriod.data.network.PersistentCookieJar
 import se.hkr.andriod.navigation.BottomNavItem
 import se.hkr.andriod.ui.screens.devicecard.DeviceHostScreen
+import se.hkr.andriod.ui.screens.roomdetails.RoomDetailsScreen
 import se.hkr.andriod.ui.screens.roomsoverviewscreen.RoomsOverviewScreen
 import se.hkr.andriod.ui.screens.settings.subscreens.accountinfo.AccountInfoScreen
 import se.hkr.andriod.ui.screens.settings.subscreens.language.LanguageScreen
@@ -174,6 +175,16 @@ fun MainScreen(
                 )
             }
 
+            composable(
+                route = Routes.ROOM_DETAILS,
+                arguments = listOf(
+                    navArgument("roomName") { type = NavType.StringType }
+                )
+            ) { backStackEntry ->
+                val roomName =
+                    backStackEntry.arguments?.getString("roomName")
+                        ?: error("Missing room name")
+            }
 
             navigation(
                 startDestination = Routes.SETTINGS,

--- a/app/src/main/java/se/hkr/andriod/ui/screens/roomdetails/RoomDetailsScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/roomdetails/RoomDetailsScreen.kt
@@ -1,0 +1,92 @@
+package se.hkr.andriod.ui.screens.roomdetails
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import se.hkr.andriod.data.network.ConnectionManager
+import se.hkr.andriod.ui.components.DeviceCardItem
+import se.hkr.andriod.ui.theme.lightBlue
+
+@Composable
+fun RoomDetailsScreen(
+    navController: NavController,
+    connectionManager: ConnectionManager,
+    roomName: String
+) {
+    val devices by connectionManager.deviceStore.devices.collectAsState()
+    val roomDevices = devices.filter {
+        it.room == roomName
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.lightBlue)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+                .padding(top = 40.dp, bottom = 12.dp)
+        ) {
+            Text(
+                text = roomName,
+                style = MaterialTheme.typography.headlineLarge
+            )
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            Text(
+                text = "${roomDevices.size} devices",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(bottom = 16.dp)
+        ) {
+            items(roomDevices) { device ->
+                DeviceCardItem(
+                    device = device,
+                    // No navigation into device page
+                    onClick = null,
+
+                    onSwitchToggle = { isOn ->
+                        val value =
+                            if (isOn)
+                                device.maxValue
+                            else
+                                device.minValue
+
+                        connectionManager.updateDeviceValue(
+                            device.id,
+                            value
+                        )
+                    },
+
+                    onAction = {
+                        connectionManager.deviceStore.updateDeviceValue(
+                            device.id,
+                            device.minValue.toString()
+                        )
+                    },
+                    elevation = 2.dp
+                )
+            }
+            item {
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+        }
+    }
+}

--- a/app/src/main/java/se/hkr/andriod/ui/screens/roomdetails/RoomDetailsScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/roomdetails/RoomDetailsScreen.kt
@@ -10,11 +10,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import se.hkr.andriod.data.network.ConnectionManager
 import se.hkr.andriod.ui.components.DeviceCardItem
 import se.hkr.andriod.ui.theme.lightBlue
+import se.hkr.andriod.R
 
 @Composable
 fun RoomDetailsScreen(
@@ -46,7 +48,11 @@ fun RoomDetailsScreen(
             Spacer(modifier = Modifier.height(4.dp))
 
             Text(
-                text = "${roomDevices.size} devices",
+                text = pluralStringResource(
+                    R.plurals.device_count,
+                    roomDevices.size,
+                    roomDevices.size
+                ),
                 style = MaterialTheme.typography.bodyLarge,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )

--- a/app/src/main/java/se/hkr/andriod/ui/screens/roomsoverviewscreen/RoomsOverviewScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/roomsoverviewscreen/RoomsOverviewScreen.kt
@@ -31,6 +31,7 @@ import se.hkr.andriod.R
 import se.hkr.andriod.data.network.ConnectionManager
 import se.hkr.andriod.domain.model.device.Device
 import se.hkr.andriod.domain.model.device.DeviceType
+import se.hkr.andriod.navigation.Routes
 import se.hkr.andriod.ui.components.AddDeviceBottomSheet
 import se.hkr.andriod.ui.components.AppHomeTopBar
 import se.hkr.andriod.ui.components.AppTextField
@@ -136,7 +137,7 @@ fun RoomsOverviewScreen(
                     deviceCount = roomDevices.size,
                     enabled = switchDevices.isNotEmpty(),
                     checked = roomEnabled,
-                    onClick = { /* todo: navigate to room overview */},
+                    onClick = { navController.navigate(Routes.roomDetails(room)) },
                     onSwitchToggle = { turnOn ->
                         switchDevices.forEach { device ->
                             val value =

--- a/app/src/main/java/se/hkr/andriod/ui/screens/roomsoverviewscreen/RoomsOverviewScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/roomsoverviewscreen/RoomsOverviewScreen.kt
@@ -2,7 +2,20 @@ package se.hkr.andriod.ui.screens.roomsoverviewscreen
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -10,16 +23,21 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import se.hkr.andriod.R
 import se.hkr.andriod.data.network.ConnectionManager
+import se.hkr.andriod.domain.model.device.Device
+import se.hkr.andriod.domain.model.device.DeviceType
 import se.hkr.andriod.ui.components.AddDeviceBottomSheet
 import se.hkr.andriod.ui.components.AppHomeTopBar
+import se.hkr.andriod.ui.components.AppTextField
+import se.hkr.andriod.ui.components.RoomCardItem
 import se.hkr.andriod.ui.screens.main.goToRooms
 import se.hkr.andriod.ui.screens.main.goToSchedules
+import se.hkr.andriod.ui.theme.cardBackground
 import se.hkr.andriod.ui.theme.lightBlue
 
 @Composable
@@ -31,11 +49,38 @@ fun RoomsOverviewScreen(
 
     val devices by connectionManager.deviceStore.devices.collectAsState()
 
+    val search = remember { mutableStateOf("") }
 
     val onlineCount = devices.count { it.online }
     val offlineCount = devices.count { !it.online }
 
-    Box(
+    fun isSwitchDevice(device: Device): Boolean {
+        return device.deviceTypeEnum in listOf(
+            DeviceType.LIGHT,
+            DeviceType.LOCK,
+            DeviceType.FAN,
+            DeviceType.SERVO,
+            DeviceType.DOOR,
+            DeviceType.WINDOW
+        )
+    }
+
+    // Group only devices that belong to rooms
+    val devicesByRoom = devices
+        .filter {
+            !it.room.isNullOrBlank() &&
+                    it.room != "null"
+        }
+        .filter {
+            val query = search.value.trim()
+
+            it.room?.contains(query, ignoreCase = true) == true
+        }
+        .groupBy { it.room!! }
+
+    val sortedRooms = devicesByRoom.keys.sorted()
+
+    Column(
         modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.lightBlue)
@@ -47,11 +92,71 @@ fun RoomsOverviewScreen(
             onAddClick = { showAddSheet = true }
         )
 
-        // Main content
-        Box(
+        // Search bar
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 10.dp),
+            shape = MaterialTheme.shapes.medium,
+            elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.cardBackground
+            )
+        ) {
+            AppTextField(
+                value = search.value,
+                onValueChange = { search.value = it },
+                placeholder = stringResource(R.string.search_placeholder),
+                leadingIcon = Icons.Default.Search,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 10.dp)
+                    .offset(y = 10.dp)
+            )
+        }
+
+        // Rooms list
+        LazyColumn(
             modifier = Modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center
-        ) {}
+            contentPadding = PaddingValues(vertical = 16.dp)
+        ) {
+            items(sortedRooms) { room ->
+                val roomDevices = devicesByRoom[room] ?: emptyList()
+                val switchDevices = roomDevices.filter {
+                    isSwitchDevice(it)
+                }
+
+                // Room switch is ON if any switch device is ON
+                val roomEnabled = switchDevices.any {
+                    it.value > it.minValue
+                }
+
+                RoomCardItem(
+                    roomName = room,
+                    deviceCount = roomDevices.size,
+                    enabled = switchDevices.isNotEmpty(),
+                    checked = roomEnabled,
+                    onSwitchToggle = { turnOn ->
+                        switchDevices.forEach { device ->
+                            val value =
+                                if (turnOn)
+                                    device.maxValue
+                                else
+                                    device.minValue
+
+                            connectionManager.updateDeviceValue(
+                                device.id,
+                                value
+                            )
+                        }
+                    },
+                    elevation = 2.dp
+                )
+            }
+            item {
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+        }
 
         // Bottom sheet for add options
         Box {

--- a/app/src/main/java/se/hkr/andriod/ui/screens/roomsoverviewscreen/RoomsOverviewScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/roomsoverviewscreen/RoomsOverviewScreen.kt
@@ -136,6 +136,7 @@ fun RoomsOverviewScreen(
                     deviceCount = roomDevices.size,
                     enabled = switchDevices.isNotEmpty(),
                     checked = roomEnabled,
+                    onClick = { /* todo: navigate to room overview */},
                     onSwitchToggle = { turnOn ->
                         switchDevices.forEach { device ->
                             val value =

--- a/app/src/main/java/se/hkr/andriod/ui/screens/roomsoverviewscreen/RoomsOverviewScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/roomsoverviewscreen/RoomsOverviewScreen.kt
@@ -1,0 +1,73 @@
+package se.hkr.andriod.ui.screens.roomsoverviewscreen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.navigation.NavController
+import se.hkr.andriod.R
+import se.hkr.andriod.data.network.ConnectionManager
+import se.hkr.andriod.ui.components.AddDeviceBottomSheet
+import se.hkr.andriod.ui.components.AppHomeTopBar
+import se.hkr.andriod.ui.screens.main.goToRooms
+import se.hkr.andriod.ui.screens.main.goToSchedules
+import se.hkr.andriod.ui.theme.lightBlue
+
+@Composable
+fun RoomsOverviewScreen(
+    navController: NavController,
+    connectionManager: ConnectionManager
+) {
+    var showAddSheet by remember { mutableStateOf(false) }
+
+    val devices by connectionManager.deviceStore.devices.collectAsState()
+
+
+    val onlineCount = devices.count { it.online }
+    val offlineCount = devices.count { !it.online }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.lightBlue)
+    ) {
+        AppHomeTopBar(
+            title = stringResource(R.string.rooms),
+            onlineCount = onlineCount,
+            offlineCount = offlineCount,
+            onAddClick = { showAddSheet = true }
+        )
+
+        // Main content
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {}
+
+        // Bottom sheet for add options
+        Box {
+            if (showAddSheet) {
+                AddDeviceBottomSheet(
+                    onDismiss = { showAddSheet = false },
+                    onSchedulesClick = {
+                        showAddSheet = false
+                        navController.goToSchedules()
+                    },
+                    onCreateRoomClick = {
+                        showAddSheet = false
+                        navController.goToRooms()
+                    }
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -39,6 +39,12 @@
     <string name="device_overview">Eszközök áttekintése</string>
     <string name="search_placeholder">Keresés itt...</string>
 
+    <!-- Rooms overview -->
+    <plurals name="device_count">
+        <item quantity="one">%d eszköz</item>
+        <item quantity="other">%d eszköz</item>
+    </plurals>
+
     <!-- Device management -->
     <string name="device_management">Eszközkezelés</string>
 

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -42,6 +42,12 @@
     <string name="device_overview">Enhetsöversikt</string>
     <string name="search_placeholder">Sök här...</string>
 
+    <!-- Rooms overview -->
+    <plurals name="device_count">
+        <item quantity="one">%d enhet</item>
+        <item quantity="other">%d enheter</item>
+    </plurals>
+
     <!-- Device management -->
     <string name="device_management">Enhetshantering</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,6 +38,12 @@
     <string name="device_overview">Device Overview</string>
     <string name="search_placeholder">Search here...</string>
 
+    <!-- Rooms overview -->
+    <plurals name="device_count">
+        <item quantity="one">%d device</item>
+        <item quantity="other">%d devices</item>
+    </plurals>
+
     <!-- Device management -->
     <string name="device_management">Device Management</string>
 


### PR DESCRIPTION
Replaced Device management screen with a Rooms overview screen.
The rooms overview allows the user to see rooms for the current user devices.
The rooms can be interacted with (group actions that affect all "switch" type devices).
When clicking on a room card, it navigates to a screen which displays room name followed by all of the rooms devices (using deviceCardItem).