### PR TITLE
Fix: Automatic token refresh now works. Refactored ConnectionManager …

### DIFF
--- a/app/src/main/java/se/hkr/andriod/data/network/ConnectionManager.kt
+++ b/app/src/main/java/se/hkr/andriod/data/network/ConnectionManager.kt
@@ -51,51 +51,66 @@ class ConnectionManager(private val udpPort: Int = 4444) {
             return
         }
 
-        val token = AuthSession.getToken()
+        val token = AuthSession.getToken() ?: return
 
-        if (token == null) {
-            Log.d("CONNECTION", "No token available, cannot connect")
-            return
+        Log.d("CONNECTION", "Connecting WebSocket")
+
+        hasTriedRefresh = false
+
+        webSocketManager.clearMessageListeners()
+
+        webSocketManager.setOnOpenListener {
+            Log.d("CONNECTION", "Socket opened")
         }
 
-        Log.d("CONNECTION", "Connecting WebSocket with token")
-
-        webSocketManager.connect(ip)
-
-        // Failure message listener
         webSocketManager.setOnFailureListener {
             Log.d("CONNECTION", "WebSocket failed")
-
-            if (!hasTriedRefresh) {
-                Log.d("CONNECTION", "Trying refresh...")
-
-                hasTriedRefresh = true
-
-                val authService = AuthService(context)
-
-                authService.refresh(ip) { success, newToken ->
-                    if (success && newToken != null) {
-                        Log.d("CONNECTION", "Refresh successful, retrying connection")
-
-                        AuthSession.saveToken(context, newToken)
-                        connectWebSocket(context) // retry
-                    } else {
-                        Log.d("CONNECTION", "Refresh failed, user must log in again")
-                        onAuthFailure?.invoke()
-                    }
-                }
-            } else {
-                Log.d("CONNECTION", "Already tried refresh, giving up")
-            }
+            handleConnectionLost(context)
         }
-
-        // Normal message listener
-        webSocketManager.clearMessageListeners()
 
         webSocketManager.addMessageListener { message ->
             Log.d("CONNECTION", "Received message: $message")
             messageRouter.handle(message)
         }
+
+        webSocketManager.connect(ip)
+    }
+
+    private fun handleConnectionLost(context: Context) {
+        if (hasTriedRefresh) {
+            Log.d("CONNECTION", "Already tried refresh, giving up")
+            return
+        }
+
+        hasTriedRefresh = true
+
+        val ip = backendIp ?: return
+        val authService = AuthService(context)
+
+        Log.d("CONNECTION", "Refreshing token...")
+
+        authService.refresh(ip) { success, newToken ->
+
+            if (success && newToken != null) {
+
+                AuthSession.saveToken(context, newToken)
+
+                Log.d("CONNECTION", "Refresh success: reconnecting")
+
+                webSocketManager.disconnect()
+                connectWebSocket(context)
+
+            } else {
+                Log.d("CONNECTION", "Refresh failed")
+                onAuthFailure?.invoke()
+            }
+        }
+    }
+
+    fun reconnectWebSocket(context: Context) {
+        Log.d("CONNECTION", "Manual reconnect")
+        webSocketManager.disconnect()
+        connectWebSocket(context)
     }
 
     fun sendMessage(message: String) {
@@ -119,13 +134,5 @@ class ConnectionManager(private val udpPort: Int = 4444) {
         hasTriedRefresh = false // reset for next session
     }
 
-    fun getBackendIp(): String? {
-        return backendIp
-    }
-
-    fun reconnectWebSocket(context: Context) {
-        Log.d("CONNECTION", "Manual reconnect triggered")
-        disconnect()
-        connectWebSocket(context)
-    }
+    fun getBackendIp(): String? = backendIp
 }

--- a/app/src/main/java/se/hkr/andriod/data/network/WebSocketManager.kt
+++ b/app/src/main/java/se/hkr/andriod/data/network/WebSocketManager.kt
@@ -11,12 +11,25 @@ class WebSocketManager {
     private val messageListeners = mutableListOf<(String) -> Unit>()
 
     private var onFailureListener: (() -> Unit)? = null
+    private var onOpenListener: (() -> Unit)? = null
+
+    // Prevent stale socket callbacks
+    private var currentSocketId = 0
+
+    private var manualDisconnect = false
 
     fun setOnFailureListener(listener: () -> Unit) {
         onFailureListener = listener
     }
 
+    fun setOnOpenListener(listener: () -> Unit) {
+        onOpenListener = listener
+    }
+
     fun connect(ip: String, port: Int = 8080) {
+        manualDisconnect = false
+        currentSocketId++
+        val socketId = currentSocketId
 
         val token = AuthSession.getToken()
 
@@ -33,10 +46,13 @@ class WebSocketManager {
         webSocket = client.newWebSocket(request, object : WebSocketListener() {
 
             override fun onOpen(webSocket: WebSocket, response: Response) {
+                if (socketId != currentSocketId) return
                 Log.d("WEBSOCKET", "Connected")
+                onOpenListener?.invoke()
             }
 
             override fun onMessage(webSocket: WebSocket, text: String) {
+                if (socketId != currentSocketId) return
                 Log.d("WEBSOCKET", "Received: $text")
                 messageListeners.forEach { it(text) }
             }
@@ -47,10 +63,17 @@ class WebSocketManager {
             }
 
             override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
+                if (socketId != currentSocketId) return
+
                 Log.d("WEBSOCKET", "Closed: $code / $reason")
+
+                if (!manualDisconnect) {
+                    onFailureListener?.invoke()
+                }
             }
 
             override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+                if (socketId != currentSocketId) return
                 Log.d("WEBSOCKET", "Failure: ${t.message}")
                 onFailureListener?.invoke()
             }
@@ -71,6 +94,8 @@ class WebSocketManager {
     }
 
     fun disconnect() {
+        manualDisconnect = true
+        currentSocketId++
         webSocket?.close(1000, "App closed")
         webSocket = null
         clearMessageListeners()


### PR DESCRIPTION
…and WebSocketManager to correctly allow for manual and automatic refresh.