### PR TITLE
AuthSession.getUser will return a dummy user with no permissions if s…

### DIFF
--- a/app/src/main/java/se/hkr/andriod/data/network/AuthSession.kt
+++ b/app/src/main/java/se/hkr/andriod/data/network/AuthSession.kt
@@ -90,8 +90,10 @@ object AuthSession {
     fun getUser(): User {
         val role = UserRole.fromBackendType(role ?: "user")
 
+        // Return a dummy user with no permissions if session is cleared
+        // This prevents crashes during logout transitions in the ui
         return User(
-            id = userId ?: error("No userId in session"),
+            id = userId ?: UUID(0L, 0L),
             username = username ?: "",
             role = role
         )


### PR DESCRIPTION
…ession is cleared to stop crashes when the server closes the connecton.