### PR TITLE
188 add navigation from devicescreen to schedules

### DIFF
--- a/app/src/main/java/se/hkr/andriod/ui/screens/devicecard/DeviceCardScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/devicecard/DeviceCardScreen.kt
@@ -25,12 +25,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
 import se.hkr.andriod.R
 import se.hkr.andriod.domain.model.device.Device
 import se.hkr.andriod.data.network.ConnectionManager
 import se.hkr.andriod.ui.components.DeviceCardItem
 import se.hkr.andriod.ui.components.AppButton
 import se.hkr.andriod.ui.components.CustomScreenHeader
+import se.hkr.andriod.ui.screens.main.goToSchedules
 import se.hkr.andriod.ui.theme.cardBackground
 import se.hkr.andriod.ui.theme.lightBlue
 
@@ -39,6 +41,7 @@ fun DeviceCardScreen(
     device: Device,
     viewModel: DeviceCardViewModel,
     connectionManager: ConnectionManager,
+    navController: NavController,
     onBackClick: () -> Unit,
 
     // Dynamic device specific content injected from device layer
@@ -150,7 +153,10 @@ fun DeviceCardScreen(
 
                             AppButton(
                                 text = stringResource(R.string.add_new_schedule),
-                                onClick = { /*TODO*/ }
+                                onClick = {
+                                    navController.popBackStack()
+                                    navController.goToSchedules()
+                                }
                             )
                         }
                     }

--- a/app/src/main/java/se/hkr/andriod/ui/screens/devicecard/DeviceCardScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/devicecard/DeviceCardScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import se.hkr.andriod.R
+import se.hkr.andriod.data.network.AuthSession.getUser
 import se.hkr.andriod.domain.model.device.Device
 import se.hkr.andriod.data.network.ConnectionManager
 import se.hkr.andriod.ui.components.DeviceCardItem
@@ -54,6 +55,8 @@ fun DeviceCardScreen(
     val liveDevice = devices.firstOrNull { it.id == device.id } ?: device
 
     val scrollState = rememberScrollState()
+
+    val currentUser = getUser()
 
     Box(
         modifier = Modifier
@@ -151,13 +154,15 @@ fun DeviceCardScreen(
 
                             Spacer(modifier = Modifier.height(20.dp))
 
-                            AppButton(
-                                text = stringResource(R.string.add_new_schedule),
-                                onClick = {
-                                    navController.popBackStack()
-                                    navController.goToSchedules()
-                                }
-                            )
+                            if (currentUser.canManageSchedules()) {
+                                AppButton(
+                                    text = stringResource(R.string.add_new_schedule),
+                                    onClick = {
+                                        navController.popBackStack()
+                                        navController.goToSchedules()
+                                    }
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/se/hkr/andriod/ui/screens/devicecard/DeviceHostScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/devicecard/DeviceHostScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.remember
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
 import se.hkr.andriod.domain.model.device.Device
 import se.hkr.andriod.domain.model.device.DeviceType
 import se.hkr.andriod.ui.devices.light.LightDeviceRenderer
@@ -38,6 +39,7 @@ class DeviceViewModelFactory(
 fun DeviceHostScreen(
     device: Device,
     connectionManager: ConnectionManager,
+    navController: NavController,
     onBackClick: () -> Unit
 ) {
     val deviceCardViewModel: DeviceCardViewModel = viewModel()
@@ -46,6 +48,7 @@ fun DeviceHostScreen(
         device = device,
         viewModel = deviceCardViewModel,
         connectionManager = connectionManager,
+        navController = navController,
         onBackClick = onBackClick
     ) { liveDevice ->
         val factory = remember(device.id) {

--- a/app/src/main/java/se/hkr/andriod/ui/screens/main/MainScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/main/MainScreen.kt
@@ -177,7 +177,7 @@ fun MainScreen(
                         CircularProgressIndicator()
                     }
                 } else {
-                    DeviceHostScreen(device, connectionManager) { navController.navigateUp() }
+                    DeviceHostScreen(device, connectionManager, navController) { navController.navigateUp() }
                 }
             }
 


### PR DESCRIPTION
Pressing the "add new schedule" button when on a deviceScreen navigate to schedules screen.
"add new schedule" button is only visible when admin.