### PR TITLE
194 navigate to login if udp discovery fails

### DIFF
--- a/app/src/main/java/se/hkr/andriod/data/network/ConnectionManager.kt
+++ b/app/src/main/java/se/hkr/andriod/data/network/ConnectionManager.kt
@@ -34,12 +34,23 @@ class ConnectionManager(
         onAuthFailure = listener
     }
 
+    fun triggerAuthFailure() {
+        onAuthFailure?.invoke()
+    }
+
     fun startConnection(onResult: (String?) -> Unit) {
+        // If we already have an IP, don't perform UDP discovery again.
+        backendIp?.let {
+            Log.d("CONNECTION", "Using existing backend IP: $it")
+            onResult(it)
+            return
+        }
+
+        Log.d("CONNECTION", "No backend IP, starting UDP discovery")
         udpDiscovery.discoverServer(port = udpPort) { ip ->
             if (ip != null) {
                 Log.d("CONNECTION", "Backend discovered at $ip")
                 backendIp = ip
-
                 onResult(ip)
             } else {
                 Log.d("CONNECTION", "Backend discovery failed")
@@ -135,7 +146,9 @@ class ConnectionManager(
         userStore.clear()
         roomStore.clear()
 
-        hasTriedRefresh = false // reset for next session
+        // Reset for next session
+        backendIp = null
+        hasTriedRefresh = false
     }
 
     fun getBackendIp(): String? = backendIp

--- a/app/src/main/java/se/hkr/andriod/data/network/UdpDiscovery.kt
+++ b/app/src/main/java/se/hkr/andriod/data/network/UdpDiscovery.kt
@@ -1,5 +1,7 @@
 package se.hkr.andriod.data.network
 
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import se.hkr.andriod.utils.DeviceUtils
 import java.net.DatagramPacket
@@ -8,13 +10,15 @@ import java.net.InetAddress
 
 class UdpDiscovery {
     fun discoverServer(port: Int = 4444, onResult: (String?) -> Unit) {
+        val mainHandler = Handler(Looper.getMainLooper())
+
         Thread {
             try {
                 if (DeviceUtils.isEmulator()) {
                     // Emulator: skip UDP broadcast
                     val ip = "10.0.2.2"
                     Log.d("UDP", "Running on emulator, using IP: $ip")
-                    onResult(ip)
+                    mainHandler.post { onResult(ip) }
                     return@Thread
                 }
 
@@ -49,16 +53,14 @@ class UdpDiscovery {
                 Log.d("UDP", "Received UDP response from $serverIp: $responseMessage")
 
                 socket.close()
-                if (serverIp != null) {
-                    onResult(serverIp)
-                }
+                mainHandler.post { onResult(serverIp) }
 
             } catch (e: java.net.SocketTimeoutException) {
                 Log.d("UDP", "UDP discovery timed out")
-                onResult(null)
+                mainHandler.post { onResult(null) }
             } catch (e: Exception) {
-                e.printStackTrace()
-                onResult("Error: ${e.message}")
+                Log.e("UDP", "UDP discovery error", e)
+                mainHandler.post { onResult(null) }
             }
         }.start()
     }

--- a/app/src/main/java/se/hkr/andriod/navigation/AppNavGraph.kt
+++ b/app/src/main/java/se/hkr/andriod/navigation/AppNavGraph.kt
@@ -10,6 +10,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import se.hkr.andriod.core.events.ErrorDispatcher
 import se.hkr.andriod.data.network.AuthSession
+import se.hkr.andriod.data.network.ConnectionManager
 import se.hkr.andriod.ui.components.GlobalErrorSnackbarHost
 import se.hkr.andriod.ui.screens.login.LoginScreen
 import se.hkr.andriod.ui.screens.login.LoginViewModel
@@ -22,6 +23,7 @@ import se.hkr.andriod.ui.viewmodel.AuthViewModelFactory
 fun AppNavGraph(errorDispatcher: ErrorDispatcher) {
     val navController = rememberNavController()
     val context = LocalContext.current
+    val connectionManager = remember { ConnectionManager(errorDispatcher = errorDispatcher) }
 
     // Load token once when app starts
     LaunchedEffect(Unit) {
@@ -44,7 +46,7 @@ fun AppNavGraph(errorDispatcher: ErrorDispatcher) {
         startDestination = Routes.LOGIN
     ) {
         composable(Routes.LOGIN) {
-            val factory = remember { AuthViewModelFactory(context, errorDispatcher) }
+            val factory = remember { AuthViewModelFactory(context, connectionManager) }
             val loginViewModel: LoginViewModel = viewModel(factory = factory)
 
             LoginScreen(
@@ -61,7 +63,7 @@ fun AppNavGraph(errorDispatcher: ErrorDispatcher) {
         }
 
         composable(Routes.SIGN_UP) {
-            val factory = remember { AuthViewModelFactory(context, errorDispatcher) }
+            val factory = remember { AuthViewModelFactory(context, connectionManager) }
             val registerViewModel: SignUpViewModel = viewModel(factory = factory)
 
             SignUpScreen(
@@ -86,7 +88,7 @@ fun AppNavGraph(errorDispatcher: ErrorDispatcher) {
                         popUpTo(Routes.MAIN) { inclusive = true }
                     }
                 },
-                errorDispatcher = errorDispatcher
+                connectionManager = connectionManager,
             )
         }
     }

--- a/app/src/main/java/se/hkr/andriod/ui/screens/main/MainScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/main/MainScreen.kt
@@ -33,9 +33,9 @@ import androidx.navigation.NavType
 import androidx.navigation.navArgument
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
-import se.hkr.andriod.core.events.ErrorDispatcher
 import se.hkr.andriod.data.language.LanguageStorage
 import se.hkr.andriod.data.network.AuthSession
+import se.hkr.andriod.data.network.ConnectionManager
 import se.hkr.andriod.data.network.NetworkModule
 import se.hkr.andriod.data.network.PersistentCookieJar
 import se.hkr.andriod.navigation.BottomNavItem
@@ -58,12 +58,11 @@ import se.hkr.andriod.ui.theme.lightBlue
 @Composable
 fun MainScreen(
     onLogout: () -> Unit,
-    errorDispatcher: ErrorDispatcher
+    connectionManager: ConnectionManager,
 ) {
     val mainViewModel: MainViewModel = viewModel(
-        factory = MainViewModelFactory(errorDispatcher)
+        factory = MainViewModelFactory(connectionManager)
     )
-    val connectionManager = mainViewModel.connectionManager
     val navController = rememberNavController()
     val context = LocalContext.current
 

--- a/app/src/main/java/se/hkr/andriod/ui/screens/main/MainViewModel.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/main/MainViewModel.kt
@@ -20,6 +20,9 @@ class MainViewModel(
             connectionManager.startConnection { ip ->
                 if (ip != null) {
                     connectionManager.connectWebSocket(context)
+                }else {
+                    // Trigger logout if discovery fails
+                    connectionManager.triggerAuthFailure()
                 }
             }
         }

--- a/app/src/main/java/se/hkr/andriod/ui/screens/main/MainViewModel.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/main/MainViewModel.kt
@@ -7,9 +7,8 @@ import se.hkr.andriod.data.network.AuthSession
 import se.hkr.andriod.data.network.ConnectionManager
 
 class MainViewModel(
-    private val errorDispatcher: ErrorDispatcher
+    val connectionManager: ConnectionManager
 ) : ViewModel() {
-    val connectionManager = ConnectionManager(errorDispatcher = errorDispatcher)
     private var isInitialized = false
 
     fun initConnection(context: Context) {

--- a/app/src/main/java/se/hkr/andriod/ui/screens/main/MainViewModelFactory.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/main/MainViewModelFactory.kt
@@ -3,15 +3,16 @@ package se.hkr.andriod.ui.screens.main
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import se.hkr.andriod.core.events.ErrorDispatcher
+import se.hkr.andriod.data.network.ConnectionManager
 
 class MainViewModelFactory(
-    private val errorDispatcher: ErrorDispatcher
+    private val connectionManager: ConnectionManager
 ) : ViewModelProvider.Factory {
 
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(MainViewModel::class.java)) {
-            return MainViewModel(errorDispatcher) as T
+            return MainViewModel(connectionManager) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class")
     }

--- a/app/src/main/java/se/hkr/andriod/ui/viewmodel/AuthViewModelFactory.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/viewmodel/AuthViewModelFactory.kt
@@ -3,7 +3,6 @@ package se.hkr.andriod.ui.viewmodel
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import se.hkr.andriod.core.events.ErrorDispatcher
 import se.hkr.andriod.data.network.AuthService
 import se.hkr.andriod.data.network.ConnectionManager
 import se.hkr.andriod.ui.screens.login.LoginViewModel
@@ -11,12 +10,11 @@ import se.hkr.andriod.ui.screens.signup.SignUpViewModel
 
 class AuthViewModelFactory(
     private val context: Context,
-    private val errorDispatcher: ErrorDispatcher
+    private val connectionManager: ConnectionManager
 ) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
 
         val authService = AuthService(context.applicationContext)
-        val connectionManager = ConnectionManager(errorDispatcher = errorDispatcher)
 
         return when {
             modelClass.isAssignableFrom(LoginViewModel::class.java) -> {


### PR DESCRIPTION
App now logs out on failed UDP discovery.
App now shares one instance of ConnectionManager instead of having one for MainViewModel and one for AuthViewModel.