### PR TITLE
Refactored loading logic on the DeviceOverviewScreen to ensure that l…

### DIFF
--- a/app/src/main/java/se/hkr/andriod/data/network/DeviceStore.kt
+++ b/app/src/main/java/se/hkr/andriod/data/network/DeviceStore.kt
@@ -21,13 +21,17 @@ class DeviceStore(private val webSocketManager: WebSocketManager) {
     private val _allDevices = MutableStateFlow<List<Device>>(emptyList())
     val allDevices: StateFlow<List<Device>> get() = _allDevices
 
+    private val _hasReceivedInitialDevices = MutableStateFlow(false)
+    val hasReceivedInitialDevices: StateFlow<Boolean> get() = _hasReceivedInitialDevices
+
     // Coroutine scope for updates
     private val scope = CoroutineScope(Dispatchers.Main)
 
 
-    fun clear () {
+    fun clear() {
         _devices.value = emptyList()
         _allDevices.value = emptyList()
+        _hasReceivedInitialDevices.value = false
     }
 
     fun handleMessage(json: JSONObject) {
@@ -60,7 +64,10 @@ class DeviceStore(private val webSocketManager: WebSocketManager) {
             newDevices.add(device)
         }
 
-        scope.launch { _devices.value = newDevices }
+        scope.launch {
+            _devices.value = newDevices
+            _hasReceivedInitialDevices.value = true
+        }
         Log.d("DEVICESTORE", "Initial devices loaded: ${newDevices.size}")
     }
 

--- a/app/src/main/java/se/hkr/andriod/ui/screens/main/MainScreen.kt
+++ b/app/src/main/java/se/hkr/andriod/ui/screens/main/MainScreen.kt
@@ -66,8 +66,12 @@ fun MainScreen(
     val navController = rememberNavController()
     val context = LocalContext.current
 
+    val hasReceivedInitialDevices by connectionManager
+        .deviceStore
+        .hasReceivedInitialDevices
+        .collectAsState()
+
     var hasFinishedInitialLoad by remember { mutableStateOf(false) }
-    val devices by connectionManager.deviceStore.devices.collectAsState()
 
     LaunchedEffect(Unit) {
         mainViewModel.initConnection(context)
@@ -87,13 +91,12 @@ fun MainScreen(
         }
     }
 
-    LaunchedEffect(Unit) {
-        if (devices.isNotEmpty()) {
-            hasFinishedInitialLoad = true
-        } else {
-            snapshotFlow { devices }.first { it.isNotEmpty() }
+    LaunchedEffect(hasReceivedInitialDevices) {
+        if (hasReceivedInitialDevices) {
             delay(500)
             hasFinishedInitialLoad = true
+        } else {
+            hasFinishedInitialLoad = false
         }
     }
 


### PR DESCRIPTION
…oading stops when 'initial devices' message is recieved from backend instead of when devices > 0. This ensures that 'No devices' text is displayed when there are no devices.