### PR TITLE
Moved connectionManager instance to A SharedConnectionViewModel to en…

### DIFF
--- a/app/src/main/java/se/hkr/andriod/data/network/SharedConnectionViewModel.kt
+++ b/app/src/main/java/se/hkr/andriod/data/network/SharedConnectionViewModel.kt
@@ -1,0 +1,13 @@
+package se.hkr.andriod.data.network
+
+import androidx.lifecycle.ViewModel
+import se.hkr.andriod.core.events.ErrorDispatcher
+
+class SharedConnectionViewModel(errorDispatcher: ErrorDispatcher) : ViewModel() {
+    val connectionManager = ConnectionManager(errorDispatcher = errorDispatcher)
+
+    override fun onCleared() {
+        super.onCleared()
+        connectionManager.disconnect()
+    }
+}

--- a/app/src/main/java/se/hkr/andriod/navigation/AppNavGraph.kt
+++ b/app/src/main/java/se/hkr/andriod/navigation/AppNavGraph.kt
@@ -4,13 +4,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import se.hkr.andriod.core.events.ErrorDispatcher
 import se.hkr.andriod.data.network.AuthSession
-import se.hkr.andriod.data.network.ConnectionManager
+import se.hkr.andriod.data.network.SharedConnectionViewModel
 import se.hkr.andriod.ui.components.GlobalErrorSnackbarHost
 import se.hkr.andriod.ui.screens.login.LoginScreen
 import se.hkr.andriod.ui.screens.login.LoginViewModel
@@ -23,7 +25,17 @@ import se.hkr.andriod.ui.viewmodel.AuthViewModelFactory
 fun AppNavGraph(errorDispatcher: ErrorDispatcher) {
     val navController = rememberNavController()
     val context = LocalContext.current
-    val connectionManager = remember { ConnectionManager(errorDispatcher = errorDispatcher) }
+
+    // Use ViewModel to hold the ConnectionManager so it survives configuration changes (like language switch)
+    val sharedConnectionViewModel: SharedConnectionViewModel = viewModel(
+        factory = object : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                return SharedConnectionViewModel(errorDispatcher) as T
+            }
+        }
+    )
+    val connectionManager = sharedConnectionViewModel.connectionManager
 
     // Load token once when app starts
     LaunchedEffect(Unit) {
@@ -46,7 +58,7 @@ fun AppNavGraph(errorDispatcher: ErrorDispatcher) {
         startDestination = Routes.LOGIN
     ) {
         composable(Routes.LOGIN) {
-            val factory = remember { AuthViewModelFactory(context, connectionManager) }
+            val factory = remember(connectionManager) { AuthViewModelFactory(context, connectionManager) }
             val loginViewModel: LoginViewModel = viewModel(factory = factory)
 
             LoginScreen(
@@ -63,7 +75,7 @@ fun AppNavGraph(errorDispatcher: ErrorDispatcher) {
         }
 
         composable(Routes.SIGN_UP) {
-            val factory = remember { AuthViewModelFactory(context, connectionManager) }
+            val factory = remember(connectionManager) { AuthViewModelFactory(context, connectionManager) }
             val registerViewModel: SignUpViewModel = viewModel(factory = factory)
 
             SignUpScreen(


### PR DESCRIPTION
…sure that it stays across configuration changes. To ensure that the connectionManager survives when updating language.